### PR TITLE
Add as the judgment of whether the discussion exists when sync likes

### DIFF
--- a/src/Gamification.php
+++ b/src/Gamification.php
@@ -104,7 +104,7 @@ class Gamification
         if ($post && $post->user && $user) {
             Vote::updateUserVotes($post->user)->save();
 
-            if ($post->number = 1) {
+            if ($post->number = 1 && $post->$discussion != null) {
                 Vote::updateDiscussionVotes($post->discussion);
             }
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
If a discussion was deleted forever, and there is a post that originally belonged to it, $post->$discussion will return a null value. This may cause errors when adding votes for the discussion. 

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
