### PR TITLE
feat: ✨ Add group linking to rank (#38)

### DIFF
--- a/js/src/admin/components/SettingsPage.js
+++ b/js/src/admin/components/SettingsPage.js
@@ -5,6 +5,7 @@ import Switch from 'flarum/common/components/Switch';
 import withAttr from 'flarum/common/utils/withAttr';
 import Stream from 'flarum/common/utils/Stream';
 import UploadImageButton from './UploadImageButton';
+import Select from "flarum/common/components/Select";
 
 export default class SettingsPage extends ExtensionPage {
     oninit(vnode) {
@@ -39,6 +40,7 @@ export default class SettingsPage extends ExtensionPage {
             points: Stream(''),
             name: Stream(''),
             color: Stream(''),
+            groups: Stream('')
         };
     }
 
@@ -46,6 +48,9 @@ export default class SettingsPage extends ExtensionPage {
      * @returns {*}
      */
     content() {
+        const groups = {};
+        app.store.all('groups').forEach(group => groups[parseInt(group.id())] = group.nameSingular());
+
         return [
             m('div', { className: 'SettingsPage' }, [
                 m('div', { className: 'container' }, [
@@ -100,6 +105,13 @@ export default class SettingsPage extends ExtensionPage {
                                             placeholder: app.translator.trans('fof-gamification.admin.page.ranks.help.color'),
                                             oninput: withAttr('value', this.updateColor.bind(this, rank)),
                                         }),
+                                        Select.component({
+                                            className: 'FormControl Ranks-group',
+                                            options: groups,
+                                            value: Array.isArray(rank.groups()) ? rank.groups()[0] : rank.groups(),
+                                            placeholder: app.translator.trans('fof-gamification.admin.page.ranks.help.group'),
+                                            onchange: this.updateGroups.bind(this, rank),
+                                        }),
                                         Button.component({
                                             type: 'button',
                                             className: 'Button Button--warning Ranks-button',
@@ -127,6 +139,13 @@ export default class SettingsPage extends ExtensionPage {
                                         value: this.newRank.color(),
                                         placeholder: app.translator.trans('fof-gamification.admin.page.ranks.help.color'),
                                         oninput: withAttr('value', this.newRank.color),
+                                    }),
+                                    Select.component({
+                                        className: 'FormControl Ranks-group',
+                                        options: groups,
+                                        value: this.newRank.groups(),
+                                        placeholder: app.translator.trans('fof-gamification.admin.page.ranks.help.group'),
+                                        onChange: withAttr('value', this.newRank.groups),
                                     }),
                                     Button.component({
                                         type: 'button',
@@ -249,6 +268,10 @@ export default class SettingsPage extends ExtensionPage {
         rank.save({ color: value });
     }
 
+    updateGroups(rank, value) {
+        rank.save({ groups: value });
+    }
+
     deleteRank(rankToDelete) {
         rankToDelete.delete();
         this.ranks.some((rank, i) => {
@@ -266,11 +289,13 @@ export default class SettingsPage extends ExtensionPage {
                 points: this.newRank.points(),
                 name: this.newRank.name(),
                 color: this.newRank.color(),
+                groups: this.newRank.groups()
             })
             .then((rank) => {
                 this.newRank.color('');
                 this.newRank.name('');
                 this.newRank.points('');
+                this.newRank.groups('');
                 this.ranks.push(rank);
                 m.redraw();
             });

--- a/js/src/admin/components/SettingsPage.js
+++ b/js/src/admin/components/SettingsPage.js
@@ -145,7 +145,7 @@ export default class SettingsPage extends ExtensionPage {
                                         options: groups,
                                         value: this.newRank.groups(),
                                         placeholder: app.translator.trans('fof-gamification.admin.page.ranks.help.group'),
-                                        onChange: withAttr('value', this.newRank.groups),
+                                        onChange: this.newRank.groups,
                                     }),
                                     Button.component({
                                         type: 'button',

--- a/js/src/admin/components/SettingsPage.js
+++ b/js/src/admin/components/SettingsPage.js
@@ -48,7 +48,9 @@ export default class SettingsPage extends ExtensionPage {
      * @returns {*}
      */
     content() {
-        const groups = {};
+        const groups = {
+            0: null
+        };
         app.store.all('groups').forEach(group => groups[parseInt(group.id())] = group.nameSingular());
 
         return [

--- a/js/src/common/models/Rank.js
+++ b/js/src/common/models/Rank.js
@@ -5,4 +5,5 @@ export default class Rank extends mixin(Model, {
     points: Model.attribute('points'),
     name: Model.attribute('name'),
     color: Model.attribute('color'),
+    groups: Model.attribute('groups')
 }) {}

--- a/migrations/2021_05_06_000000_add_groups_to_rank.php
+++ b/migrations/2021_05_06_000000_add_groups_to_rank.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('ranks', function (Blueprint $table) {
+            $table->json('groups')->nullable();
+        });
+    },
+    'down' => function (Builder $schema) {
+        $schema->table('ranks', function (Blueprint $table) {
+            $table->dropColumn('groups');
+        });
+    },
+];

--- a/resources/less/admin/extension.less
+++ b/resources/less/admin/extension.less
@@ -30,11 +30,11 @@
     margin-top: 5px;
     margin-bottom: 5px
   }
-  
+
   .Upload-label {
     margin-right: 15px;
   }
-  
+
   .Upload-button {
     margin-top: 7.5px;
     margin-bottom: 7.5px;
@@ -43,11 +43,11 @@
   .helpText {
     margin-bottom: 20px;
   }
-  
+
   .SettingsPage-ranks {
       margin-top: 20px;
   }
-  
+
   .Ranks-number {
     width: 15%;
     float: left;
@@ -64,7 +64,7 @@
     margin: 5px 5px 5px;
   }
   .Ranks-button {
-    margin: 5px 0 5px;
+    margin: 5px 0 5px 20px;
   }
   .Ranks-default {
     width: 30%;

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -63,6 +63,6 @@ fof-gamification:
         number_title: How many rank badges should be shown?
         help:
           color: '#ffffff'
-          help: "Input the required number of upvotes, the name of the rank, and the hex color of the rank"
+          help: Input the required number of upvotes, the name of the rank, the hex color of the rank and eventually the Flarum group to associate with the user who reach the rank
           points: Points
           name: Name

--- a/src/Api/Serializers/RankSerializer.php
+++ b/src/Api/Serializers/RankSerializer.php
@@ -39,6 +39,7 @@ class RankSerializer extends AbstractSerializer
             'points' => $rank->points,
             'name'   => $rank->name,
             'color'  => $rank->color,
+            'groups' => $rank->groups
         ];
     }
 }

--- a/src/Commands/CreateRankHandler.php
+++ b/src/Commands/CreateRankHandler.php
@@ -46,7 +46,8 @@ class CreateRankHandler
         $rank = Rank::build(
             Arr::get($data, 'attributes.name'),
             Arr::get($data, 'attributes.color'),
-            Arr::get($data, 'attributes.points')
+            Arr::get($data, 'attributes.points'),
+            Arr::get($data, 'attributes.groups')
         );
 
         $this->validator->assertValid($rank->getAttributes());

--- a/src/Commands/EditRankHandler.php
+++ b/src/Commands/EditRankHandler.php
@@ -63,6 +63,11 @@ class EditRankHandler
             $rank->updateColor($attributes['color']);
         }
 
+        if (isset($attributes['groups']) && '' !== $attributes['groups']) {
+            $validate['groups'] = $attributes['groups'];
+            $rank->updateGroups($attributes['groups']);
+        }
+
         $this->validator->assertValid(array_merge($rank->getDirty(), $validate));
 
         $rank->save();

--- a/src/Listeners/AddVoteHandler.php
+++ b/src/Listeners/AddVoteHandler.php
@@ -16,6 +16,7 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Gamification\Gamification;
 use FoF\Gamification\Rank;
 use FoF\Gamification\Vote;
+use Illuminate\Support\Collection;
 
 class AddVoteHandler
 {
@@ -58,8 +59,22 @@ class AddVoteHandler
             $ranks = Rank::where('points', '<=', $actor->votes)->get();
 
             if ($ranks) {
+                assert($ranks instanceof Collection);
                 $actor->ranks()->detach();
+
+                foreach ($ranks as $rank) {
+                    foreach ($rank->groups as $group) {
+                        $actor->groups()->detach($group);
+                    }
+                }
+
                 $actor->ranks()->attach($ranks);
+
+                foreach ($ranks as $rank) {
+                    foreach ($rank->groups as $group) {
+                        $actor->groups()->attach($group);
+                    }
+                }
             }
         }
     }

--- a/src/Listeners/AddVoteHandler.php
+++ b/src/Listeners/AddVoteHandler.php
@@ -59,22 +59,11 @@ class AddVoteHandler
             $ranks = Rank::where('points', '<=', $actor->votes)->get();
 
             if ($ranks) {
-                assert($ranks instanceof Collection);
+                $actor->groups()->detach($actor->ranks()->pluck('groups'));
                 $actor->ranks()->detach();
 
-                foreach ($ranks as $rank) {
-                    foreach ($rank->groups as $group) {
-                        $actor->groups()->detach($group);
-                    }
-                }
-
                 $actor->ranks()->attach($ranks);
-
-                foreach ($ranks as $rank) {
-                    foreach ($rank->groups as $group) {
-                        $actor->groups()->attach($group);
-                    }
-                }
+                $actor->groups()->attach($ranks->pluck('groups'));
             }
         }
     }

--- a/src/Listeners/RemoveVoteHandler.php
+++ b/src/Listeners/RemoveVoteHandler.php
@@ -31,6 +31,7 @@ class RemoveVoteHandler
 
         if (null !== $ranks) {
             $user->ranks()->detach($ranks);
+            $user->groups()->detach($ranks->pluck('groups'));
         }
     }
 }

--- a/src/Listeners/SaveVotesToDatabase.php
+++ b/src/Listeners/SaveVotesToDatabase.php
@@ -196,9 +196,13 @@ class SaveVotesToDatabase
         );
 
         if ($user) {
-            $ranks = Rank::where('points', '<=', $user->votes)->pluck('id');
+            $ranks = Rank::where('points', '<=', $user->votes);
+            $old_groups = $user->ranks()->pluck('groups');
 
-            $user->ranks()->sync($ranks);
+            $user->ranks()->sync($ranks->pluck('id'));
+
+            $user->groups()->detach($old_groups);
+            $user->groups()->attach($ranks->pluck('groups'));
         }
     }
 

--- a/src/Listeners/SaveVotesToDatabase.php
+++ b/src/Listeners/SaveVotesToDatabase.php
@@ -196,13 +196,18 @@ class SaveVotesToDatabase
         );
 
         if ($user) {
-            $ranks = Rank::where('points', '<=', $user->votes);
             $old_groups = $user->ranks()->pluck('groups')->unique();
+
+            $ranks = Rank::where('points', '<=', $user->votes);
+            $new_groups = $ranks->pluck('groups')->unique();
 
             $user->ranks()->sync($ranks->pluck('id'));
 
             $user->groups()->detach($old_groups);
-            $user->groups()->attach($ranks->pluck('groups')->unique());
+
+            if (!($new_groups->containsOneItem() && $new_groups->first() === "null")) {
+                $user->groups()->attach($new_groups);
+            }
         }
     }
 

--- a/src/Listeners/SaveVotesToDatabase.php
+++ b/src/Listeners/SaveVotesToDatabase.php
@@ -197,12 +197,12 @@ class SaveVotesToDatabase
 
         if ($user) {
             $ranks = Rank::where('points', '<=', $user->votes);
-            $old_groups = $user->ranks()->pluck('groups');
+            $old_groups = $user->ranks()->pluck('groups')->unique();
 
             $user->ranks()->sync($ranks->pluck('id'));
 
             $user->groups()->detach($old_groups);
-            $user->groups()->attach($ranks->pluck('groups'));
+            $user->groups()->attach($ranks->pluck('groups')->unique());
         }
     }
 

--- a/src/Rank.php
+++ b/src/Rank.php
@@ -25,15 +25,21 @@ class Rank extends AbstractModel
      * @param string $name
      * @param string $color
      * @param int    $points
+     * @param int|array $groups
      *
      * @return static
      */
-    public static function build($name, $color, $points)
+    public static function build($name, $color, $points, $groups)
     {
         $rank = new static();
         $rank->name = $name;
         $rank->color = $color;
         $rank->points = $points;
+
+        if (is_int($groups)) {
+            $groups = [$groups];
+        }
+        $rank->groups = $groups;
 
         return $rank;
     }
@@ -70,6 +76,21 @@ class Rank extends AbstractModel
     public function updateColor($color)
     {
         $this->color = $color;
+
+        return $this;
+    }
+
+    /**
+     * @param int|array $color
+     *
+     * @return $this
+     */
+    public function updateGroups($groups)
+    {
+        if (is_int($groups)) {
+            $groups = [$groups];
+        }
+        $this->groups = $groups;
 
         return $this;
     }


### PR DESCRIPTION
**Changes proposed in this pull request:**
### New features
*   [`feat:`](https://github.com/FriendsOfFlarum/gamification/commit/c4af89c4420685c5f287adcda46399327e6733ee) :sparkles: [`Add group linking to rank`](https://github.com/FriendsOfFlarum/gamification/commit/c4af89c4420685c5f287adcda46399327e6733ee) (Check details in commit)

**Reviewers should focus on:**
Compatibility with 1.0

**Screenshot**
*   New rank field for linked group:

![](https://user-images.githubusercontent.com/9463142/118959152-56418480-b962-11eb-906b-4621e128ff25.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
