### PR TITLE
feat: ✨ Added sticky rank feature (#38)

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -13,8 +13,10 @@ namespace FoF\Gamification;
 
 use Flarum\Api\Controller;
 use Flarum\Api\Serializer;
+use Flarum\Api\Serializer\AbstractSerializer;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Extend;
+use Flarum\Group\Group;
 use Flarum\Post\Event\Deleted;
 use Flarum\Post\Event\Posted;
 use Flarum\Post\Event\Saving;
@@ -24,7 +26,9 @@ use FoF\Extend\Extend\ExtensionSettings;
 use FoF\Gamification\Api\Controllers;
 use FoF\Gamification\Api\Serializers;
 use FoF\Gamification\Gambit\HotGambit;
+use FoF\Gamification\Listeners\SyncGroupsStickyRanks;
 use FoF\Gamification\Notification\VoteBlueprint;
+use Illuminate\Support\Arr;
 
 return [
     (new Extend\Frontend('admin'))
@@ -42,6 +46,9 @@ return [
 
     (new Extend\Model(User::class))
         ->belongsToMany('ranks', Rank::class, 'rank_users'),
+
+    (new Extend\Model(Group::class))
+        ->belongsTo('sticky_rank', Rank::class,'sticky_rank'),
 
     (new Extend\Model(Post::class))
         ->relationship('upvotes', function (Post $post) {
@@ -74,7 +81,8 @@ return [
         ->get('/rankings', 'rankings', Controllers\OrderByPointsController::class),
 
     (new Extend\Event())
-        ->listen(Saving::class, Listeners\SaveVotesToDatabase::class),
+        ->listen(Saving::class, Listeners\SaveVotesToDatabase::class)
+        ->listen(\Flarum\Group\Event\Saving::class, SyncGroupsStickyRanks::class),
 
     (new Extend\ApiSerializer(Serializer\PostSerializer::class))
         ->hasMany('upvotes', Serializer\BasicUserSerializer::class),
@@ -82,12 +90,25 @@ return [
     (new Extend\ApiSerializer(Serializer\UserSerializer::class))
         ->hasMany('ranks', Serializers\RankSerializer::class),
 
+    (new Extend\ApiSerializer(Serializer\GroupSerializer::class))
+        ->hasOne('sticky_rank', Serializers\RankSerializer::class),
+
     (new Extend\ApiSerializer(Serializer\ForumSerializer::class))
         ->hasMany('ranks', Serializers\RankSerializer::class),
 
     (new Extend\ApiController(Controller\ShowForumController::class))
         ->prepareDataForSerialization(function (Controller\ShowForumController $controller, &$data) {
             $data['ranks'] = Rank::get();
+            /*$data['groups'] = Group::get();
+            foreach ($data['groups'] as $id => $group) {
+                if (!empty($group->sticky_rank)) {
+                    $group->sticky_rank()->associate(Rank::find($group->sticky_rank)->first());
+                    Arr::set($data, "groups.$id", $group);
+                }
+            }*/
+            /*echo "<pre>";
+            var_dump($data['groups'][0]);
+            echo "</pre>";*/
         }),
 
     (new Extend\Settings())
@@ -130,6 +151,15 @@ return [
     (new Extend\ApiController(Controller\UpdateUserController::class))
         ->addInclude('ranks'),
 
+    (new Extend\ApiController(Controller\ListGroupsController::class))
+        ->addInclude('sticky_rank'),
+
+    (new Extend\ApiController(Controller\CreateGroupController::class))
+        ->addInclude('sticky_rank'),
+
+    (new Extend\ApiController(Controller\UpdateGroupController::class))
+        ->addInclude('sticky_rank'),
+
     (new Extend\ApiController(Controller\ShowDiscussionController::class))
         ->addInclude('posts.user.ranks'),
 
@@ -153,6 +183,7 @@ return [
         ->addOptionalInclude('upvotes'),
 
     (new Extend\ApiController(Controller\ShowForumController::class))
+        ->addInclude('groups.sticky_rank')
         ->addInclude('ranks'),
 
     (new Extend\Notification())

--- a/extend.php
+++ b/extend.php
@@ -68,6 +68,8 @@ return [
             'rankAmt',
             'customRankingImages',
             'useAlternateLayout',
+            'allowSelfVote',
+            'onlyOneStickyRank'
         ]),
 
     (new Extend\Routes('api'))
@@ -99,16 +101,6 @@ return [
     (new Extend\ApiController(Controller\ShowForumController::class))
         ->prepareDataForSerialization(function (Controller\ShowForumController $controller, &$data) {
             $data['ranks'] = Rank::get();
-            /*$data['groups'] = Group::get();
-            foreach ($data['groups'] as $id => $group) {
-                if (!empty($group->sticky_rank)) {
-                    $group->sticky_rank()->associate(Rank::find($group->sticky_rank)->first());
-                    Arr::set($data, "groups.$id", $group);
-                }
-            }*/
-            /*echo "<pre>";
-            var_dump($data['groups'][0]);
-            echo "</pre>";*/
         }),
 
     (new Extend\Settings())

--- a/js/src/admin/components/SettingsPage.js
+++ b/js/src/admin/components/SettingsPage.js
@@ -29,7 +29,8 @@ export default class SettingsPage extends ExtensionPage {
             'rateLimit',
             'showVotesOnDiscussionPage',
             'useAlternateLayout',
-            'allowSelfVote'
+            'allowSelfVote',
+            'onlyOneStickyRank'
         ];
 
         this.ranks = app.store.all('ranks');
@@ -177,7 +178,6 @@ export default class SettingsPage extends ExtensionPage {
                                 'table',
                                 { className: 'Ranks--Container' },
                                 app.store.all('groups').map((group) => {
-                                    console.log(group.sticky_rank() ? group.sticky_rank().name() : '')
                                     return [
                                         m('tr', [
                                             m('td', GroupBadge.component({ group: group })),
@@ -197,6 +197,13 @@ export default class SettingsPage extends ExtensionPage {
                                         m('tr', {style: 'height: 8px;'})
                                     ];
                                 })
+                            ),
+                            Switch.component({
+                                    state: this.values.onlyOneStickyRank(),
+                                    onchange: this.values.onlyOneStickyRank,
+                                    className: 'votes-switch',
+                                },
+                                app.translator.trans('fof-gamification.admin.page.sticky-ranks.only_one_sticky_rank')
                             ),
                             m('label', {}, app.translator.trans('fof-gamification.admin.page.ranks.number_title')),
                             m('input', {

--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -1,9 +1,13 @@
 import app from 'flarum/admin/app';
 import SettingsPage from './components/SettingsPage';
+
+import Model from "flarum/common/Model";
 import Rank from '../common/models/Rank';
+import Group from "flarum/common/models/Group";
 
 app.initializers.add('fof-gamification', (app) => {
     app.store.models.ranks = Rank;
+    Group.prototype.sticky_rank = Model.hasOne('sticky_rank')
 
     app.extensionData
         .for('fof-gamification')

--- a/js/src/forum/addUserInfo.js
+++ b/js/src/forum/addUserInfo.js
@@ -56,9 +56,21 @@ export default function () {
 
         let sticky_ranks = [];
         if (user.groups()) {
-            sticky_ranks = user.groups().filter((group) => group.sticky_rank()).map(
-                (group) => <li className="User-Rank">{rankLabel(group.sticky_rank())}</li>
-            );
+            sticky_ranks = user.groups().filter((group) => {
+                return group.sticky_rank();
+            });
+
+            if (setting('onlyOneStickyRank')) {
+                let higher;
+                sticky_ranks.forEach((rank) => {
+                    if (!higher || rank.points > higher.points) {
+                        higher = rank;
+                    }
+                })
+                sticky_ranks = [higher];
+            }
+
+            sticky_ranks.map((group) => <li className="User-Rank">{rankLabel(group.sticky_rank())}</li>);
         }
         if (user.ranks()) {
             if (!badges_node) {
@@ -109,7 +121,19 @@ export default function () {
 
         let sticky_ranks = [];
         if (user.groups()) {
-            sticky_ranks = user.groups().filter((group) => group.sticky_rank()).map(
+            sticky_ranks = user.groups().filter((group) => group.sticky_rank());
+
+            if (setting('onlyOneStickyRank')) {
+                let higher;
+                sticky_ranks.forEach((rank) => {
+                    if (!higher || rank.points > higher.points) {
+                        higher = rank;
+                    }
+                })
+                sticky_ranks = [higher];
+            }
+
+            sticky_ranks.map(
                 (group) => <span className="User-Rank">{rankLabel(group.sticky_rank())}</span>
             );
         }

--- a/js/src/forum/addUserInfo.js
+++ b/js/src/forum/addUserInfo.js
@@ -56,22 +56,25 @@ export default function () {
 
         let sticky_ranks = [];
         if (user.groups()) {
+            // Filter groups to check which of these have a sticky rank
             sticky_ranks = user.groups().filter((group) => {
                 return group.sticky_rank();
             });
 
-            if (setting('onlyOneStickyRank')) {
+            if (setting('onlyOneStickyRank') && sticky_ranks.length) {
                 let higher;
-                sticky_ranks.forEach((rank) => {
+                sticky_ranks.forEach((group) => {
+                    const rank = group.sticky_rank()
                     if (!higher || rank.points > higher.points) {
-                        higher = rank;
+                        higher = group;
                     }
                 })
                 sticky_ranks = [higher];
             }
 
-            sticky_ranks.map((group) => <li className="User-Rank">{rankLabel(group.sticky_rank())}</li>);
+            sticky_ranks = sticky_ranks.map((group) => <li className="User-Rank">{rankLabel(group.sticky_rank())}</li>);
         }
+
         if (user.ranks()) {
             if (!badges_node) {
                 profile_node.children.splice(
@@ -123,19 +126,18 @@ export default function () {
         if (user.groups()) {
             sticky_ranks = user.groups().filter((group) => group.sticky_rank());
 
-            if (setting('onlyOneStickyRank')) {
+            if (setting('onlyOneStickyRank') && sticky_ranks.length) {
                 let higher;
-                sticky_ranks.forEach((rank) => {
+                sticky_ranks.forEach((group) => {
+                    const rank = group.sticky_rank()
                     if (!higher || rank.points > higher.points) {
-                        higher = rank;
+                        higher = group;
                     }
                 })
                 sticky_ranks = [higher];
             }
 
-            sticky_ranks.map(
-                (group) => <span className="User-Rank">{rankLabel(group.sticky_rank())}</span>
-            );
+            sticky_ranks = sticky_ranks.map((group) => <span className="User-Rank">{rankLabel(group.sticky_rank())}</span>);
         }
         header_node.children = header_node.children.concat(
             sticky_ranks.length ? sticky_ranks :

--- a/js/src/forum/addUserInfo.js
+++ b/js/src/forum/addUserInfo.js
@@ -53,9 +53,13 @@ export default function () {
         if (!profile_node) return vnode;
 
         let badges_node = profile_node.children.find(matchClass('UserCard-badges'));
-        const sticky_ranks = user.groups().filter((group) => group.sticky_rank()).map(
-            (group) => <li className="User-Rank">{rankLabel(group.sticky_rank())}</li>
-        );
+
+        let sticky_ranks = [];
+        if (user.groups()) {
+            sticky_ranks = user.groups().filter((group) => group.sticky_rank()).map(
+                (group) => <li className="User-Rank">{rankLabel(group.sticky_rank())}</li>
+            );
+        }
         if (user.ranks()) {
             if (!badges_node) {
                 profile_node.children.splice(
@@ -103,9 +107,12 @@ export default function () {
         const header_node = vnode.children.find(matchTag('h3'));
         const amt = Number(setting('rankAmt')) ?? user.ranks().length;
 
-        const sticky_ranks = user.groups().filter((group) => group.sticky_rank()).map(
-            (group) => <span className="User-Rank">{rankLabel(group.sticky_rank())}</span>
-        );
+        let sticky_ranks = [];
+        if (user.groups()) {
+            sticky_ranks = user.groups().filter((group) => group.sticky_rank()).map(
+                (group) => <span className="User-Rank">{rankLabel(group.sticky_rank())}</span>
+            );
+        }
         header_node.children = header_node.children.concat(
             sticky_ranks.length ? sticky_ranks :
             user

--- a/js/src/forum/addUserInfo.js
+++ b/js/src/forum/addUserInfo.js
@@ -50,16 +50,19 @@ export default function () {
         const profile_node = findMatchClass(vnode, 'UserCard-profile')[0];
         const amt = Number(setting('rankAmt'));
 
-        if (!profile_node) return;
+        if (!profile_node) return vnode;
 
         let badges_node = profile_node.children.find(matchClass('UserCard-badges'));
+        const sticky_ranks = user.groups().filter((group) => group.sticky_rank()).map(
+            (group) => <li className="User-Rank">{rankLabel(group.sticky_rank())}</li>
+        );
         if (user.ranks()) {
             if (!badges_node) {
                 profile_node.children.splice(
                     1,
                     0,
                     <ul className="UserCard-badges badges">
-                        {user
+                        {sticky_ranks.length ? sticky_ranks : user
                             .ranks()
                             .reverse()
                             .map((rank, i) => {
@@ -70,16 +73,19 @@ export default function () {
                     </ul>
                 );
             } else {
-                user.ranks()
+                const ranks = sticky_ranks.length ? sticky_ranks : user.ranks()
                     .reverse()
                     .map((rank, i) => {
                         if (!amt || i < amt) {
                             return <li className="User-Rank">{rankLabel(rank)}</li>;
                         }
-                    })
-                    .forEach((rank) => {
-                        badges_node.children.push(rank);
                     });
+                ranks.forEach((rank) => {
+                    if (!rank) {
+                        return;
+                    }
+                    badges_node.children.push(rank);
+                });
             }
         }
 
@@ -95,20 +101,21 @@ export default function () {
         }
 
         const header_node = vnode.children.find(matchTag('h3'));
-        const amt = Number(setting('rankAmt'));
+        const amt = Number(setting('rankAmt')) ?? user.ranks().length;
 
-        header_node.children.push(
+        const sticky_ranks = user.groups().filter((group) => group.sticky_rank()).map(
+            (group) => <span className="User-Rank">{rankLabel(group.sticky_rank())}</span>
+        );
+        header_node.children = header_node.children.concat(
+            sticky_ranks.length ? sticky_ranks :
             user
                 .ranks()
                 .reverse()
-                .map((rank, i) => {
-                    if (!amt || i < amt) {
-                        return <span className="Post-Rank">{rankLabel(rank)}</span>;
-                    }
+                .splice(0, amt)
+                .map((rank) => {
+                    return <span className="Post-Rank">{rankLabel(rank)}</span>;
                 })
-        );
-
-        header_node.children = header_node.children.filter(function (el) {
+        ).filter(function (el) {
             return el.tag !== undefined;
         });
     });

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -2,6 +2,7 @@ import Model from 'flarum/common/Model';
 import Discussion from 'flarum/common/models/Discussion';
 import Post from 'flarum/common/models/Post';
 import User from 'flarum/common/models/User';
+import Group from 'flarum/common/models/Group';
 
 import Rank from '../common/models/Rank';
 
@@ -25,6 +26,8 @@ app.initializers.add('fof-gamification', (app) => {
 
     User.prototype.points = Model.attribute('points');
     User.prototype.ranks = Model.hasMany('ranks');
+
+    Group.prototype.sticky_rank = Model.hasOne('sticky_rank');
 
     Post.prototype.upvotes = Model.hasMany('upvotes');
 

--- a/migrations/2021_05_14_000000_add_sticky_rank_to_groups.php
+++ b/migrations/2021_05_14_000000_add_sticky_rank_to_groups.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        if ($schema->hasColumn('groups', 'sticky_rank')) {
+            return;
+        }
+
+        $schema->table('groups', function (Blueprint $table) {
+            $table->integer('sticky_rank')->nullable();
+        });
+    },
+    'down' => function (Builder $schema) {
+        $schema->table('groups', function (Blueprint $table) {
+            $table->dropColumn('sticky_rank');
+        });
+    },
+];

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -66,3 +66,10 @@ fof-gamification:
           help: "Input the required number of upvotes, the name of the rank, and the hex color of the rank"
           points: Points
           name: Name
+          group: Group
+          sticky_group: Sticky group
+      sticky-ranks:
+        title: Sticky Ranks
+        label: Prefixed ranks for a group
+        help: Add a sticky rank to a group. This will be displayed over the real rank (replaces the real rank label)
+

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -72,4 +72,5 @@ fof-gamification:
         title: Sticky Ranks
         label: Prefixed ranks for a group
         help: Add a sticky rank to a group. This will be displayed over the real rank (replaces the real rank label)
+        only_one_sticky_rank: Display only one sticky rank instead of all the sticky ranks (if a user is part of multiple groups, which have different sticky ranks, only the rank with higher points will be displayed)
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -23,6 +23,7 @@ fof-gamification:
       title: Voters
       upvotes_label: 'Upvoters:'
     mod_item: View Voters
+    no_autovote_message: You are not allowed to vote your own post
   admin:
     permissions:
       vote_label: Upvote/Downvote posts
@@ -43,7 +44,8 @@ fof-gamification:
         points_title: Points Placeholder
         points_placeholder: "Points: "
         color_holder: '#ffffff'
-        auto_upvote: Auto upvote posts when posted
+        allow_selfvote: Allow users to vote their own posts (Self vote)
+        auto_upvote: Auto upvote posts when posted (works only when the self vote option is enabled)
         rate_limit: Enforce a vote rate limit (10 seconds)
         discussion_page: Show total votes of original post on discussions list
         alternate_layout: Use alternate layout to show and/or do upvotes/downvotes
@@ -63,7 +65,7 @@ fof-gamification:
         number_title: How many rank badges should be shown?
         help:
           color: '#ffffff'
-          help: "Input the required number of upvotes, the name of the rank, and the hex color of the rank"
+          help: Input the required upvotes, rank name, rank color (hex) and (optionally) the group to add the user to after achieving the rank
           points: Points
           name: Name
           group: Group

--- a/src/Listeners/SyncGroupsStickyRanks.php
+++ b/src/Listeners/SyncGroupsStickyRanks.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Gamification\Listeners;
+
+use Flarum\Group\Event\Saving;
+use FoF\Gamification\Rank;
+use Illuminate\Support\Arr;
+
+class SyncGroupsStickyRanks
+{
+    public function handle(Saving $event)
+    {
+        $group = $event->group;
+        if ($group) {
+            $rank = Arr::get($event->data, 'relationships.sticky_rank.data.id');
+            if (empty($rank)) {
+                $group->sticky_rank()->dissociate();
+            } else {
+                $group->sticky_rank()->associate(Rank::where('id', $rank)->first());
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**
### New features
*   [`feat:`](https://github.com/FriendsOfFlarum/gamification/commit/9e458d4a5a8574e6ba313675d044591a0b1806d7) :sparkles: [`Added sticky group feature`](https://github.com/FriendsOfFlarum/gamification/commit/9e458d4a5a8574e6ba313675d044591a0b1806d7)
*   [`feat:`](https://github.com/FriendsOfFlarum/gamification/commit/1bb3967698c3f4b7c94c6eff1fed968938d48a6d) :sparkles: [`Added option to only display the sticky rank with higher points`](https://github.com/FriendsOfFlarum/gamification/commit/1bb3967698c3f4b7c94c6eff1fed968938d48a6d)

**Reviewers should focus on:**
Compataibility with Flarum 1.0

**Screenshot**
*   New sticky ranks section:

![](https://user-images.githubusercontent.com/9463142/118959241-6f4a3580-b962-11eb-9ee0-7183611cff04.png)

*   New "only one sticky rank" switch:

![](https://user-images.githubusercontent.com/9463142/118959295-796c3400-b962-11eb-862b-56e9c085b453.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
