### PR TITLE
Add timestamps to `post_votes` table

### DIFF
--- a/migrations/2022_02_04_000000_add_created_at_to_post_votes_table.php
+++ b/migrations/2022_02_04_000000_add_created_at_to_post_votes_table.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+
+return Migration::addColumns('post_votes', [
+    'created_at' => [
+        'timestamp',
+        'null'       => false,
+        'useCurrent' => true,
+    ],
+]);

--- a/migrations/2022_02_04_000000_add_timestamps_to_post_votes_table.php
+++ b/migrations/2022_02_04_000000_add_timestamps_to_post_votes_table.php
@@ -17,4 +17,9 @@ return Migration::addColumns('post_votes', [
         'null'       => false,
         'useCurrent' => true,
     ],
+    'updated_at' => [
+        'timestamp',
+        'null'       => false,
+        'useCurrent' => true,
+    ],
 ]);

--- a/migrations/2022_02_04_000000_add_timestamps_to_post_votes_table.php
+++ b/migrations/2022_02_04_000000_add_timestamps_to_post_votes_table.php
@@ -14,12 +14,10 @@ use Flarum\Database\Migration;
 return Migration::addColumns('post_votes', [
     'created_at' => [
         'timestamp',
-        'null'       => false,
-        'useCurrent' => true,
+        'nullable'   => true,
     ],
     'updated_at' => [
         'timestamp',
-        'null'       => false,
-        'useCurrent' => true,
+        'nullable'   => true,
     ],
 ]);

--- a/src/Vote.php
+++ b/src/Vote.php
@@ -28,6 +28,13 @@ class Vote extends AbstractModel
 {
     protected $table = 'post_votes';
 
+    protected $dates = [
+        'created_at',
+        'updated_at',
+    ];
+
+    public $timestamps = true;
+
     /**
      * @param Post $post
      * @param User $user


### PR DESCRIPTION
**Changes proposed in this pull request:**
Added `created_at` to `post_votes` table.
 This is analog to https://github.com/flarum/core/issues/2840 & https://github.com/flarum/likes/pull/28

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
