### PR TITLE
Permissions check against vote type

### DIFF
--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -41,6 +41,22 @@ app.initializers.add('fof-gamification', (app) => {
       },
       'view'
     )
+    .registerPermission(
+      {
+        icon: 'fas fa-bell',
+        label: app.translator.trans('fof-gamification.admin.permissions.upvote_notifications'),
+        permission: 'discussion.upvote_notifications'
+      },
+      'view'
+    )
+    .registerPermission(
+      {
+        icon: 'fas fa-bell',
+        label: app.translator.trans('fof-gamification.admin.permissions.downvote_notifications'),
+        permission: 'discussion.downvote_notifications'
+      },
+      'view'
+    )
     .registerPage(SettingsPage);
 });
 

--- a/migrations/2022_02_06_add_default_notification_permissions.php
+++ b/migrations/2022_02_06_add_default_notification_permissions.php
@@ -1,0 +1,9 @@
+<?php
+
+use Flarum\Database\Migration;
+use Flarum\Group\Group;
+
+return Migration::addPermissions([
+    'discussion.upvote_notifications' => Group::MEMBER_ID,
+    'discussion.downvote_notifications' => Group::MEMBER_ID
+]);

--- a/migrations/2022_02_06_add_default_notification_permissions.php
+++ b/migrations/2022_02_06_add_default_notification_permissions.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Flarum\Database\Migration;
 use Flarum\Group\Group;
 
 return Migration::addPermissions([
-    'discussion.upvote_notifications' => Group::MEMBER_ID,
-    'discussion.downvote_notifications' => Group::MEMBER_ID
+    'discussion.upvote_notifications'   => Group::MEMBER_ID,
+    'discussion.downvote_notifications' => Group::MEMBER_ID,
 ]);

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -41,6 +41,8 @@ fof-gamification:
       see_votes_label: See up/down vote count
       see_voters_label: See who voted
       see_ranking_page: See ranking page
+      upvote_notifications: Receive notifications on upvote
+      downvote_notifications: Receive notifications on downvote
     page:
       rankings:
         blocked:

--- a/src/Jobs/VoteNotificationsJob.php
+++ b/src/Jobs/VoteNotificationsJob.php
@@ -54,10 +54,13 @@ class VoteNotificationsJob implements ShouldQueue
             }
         } elseif ($user && $user->id !== $this->vote->user->id && $this->vote->value !== 0) {
             if ($user->can('canSeeVoters', $post->discussion)) {
-                $notifications->sync(
-                    new VoteBlueprint($this->vote),
-                    [$user]
-                );
+
+                if ($this->vote->value === 1 && $user->can('upvote_notifications', $post->discussion) || $this->vote->value === -1 && $user->can('downvote_notifications', $post->discussion)) {
+                    $notifications->sync(
+                        new VoteBlueprint($this->vote),
+                        [$user]
+                    );
+                }
             }
         }
     }

--- a/src/Jobs/VoteNotificationsJob.php
+++ b/src/Jobs/VoteNotificationsJob.php
@@ -54,7 +54,6 @@ class VoteNotificationsJob implements ShouldQueue
             }
         } elseif ($user && $user->id !== $this->vote->user->id && $this->vote->value !== 0) {
             if ($user->can('canSeeVoters', $post->discussion)) {
-
                 if ($this->vote->value === 1 && $user->can('upvote_notifications', $post->discussion) || $this->vote->value === -1 && $user->can('downvote_notifications', $post->discussion)) {
                     $notifications->sync(
                         new VoteBlueprint($this->vote),


### PR DESCRIPTION
Before sending up/downvote notifications, check if the user is allowed to receive them.

Permissions default to `member`
