### PR TITLE
fix: load discussion voting info on BasicDiscussionSerializer

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -129,9 +129,6 @@ return [
             return $attributes;
         }),
 
-    (new Extend\ApiSerializer(Serializer\DiscussionSerializer::class))
-        ->attributes(AddDiscussionData::class),
-
     (new Extend\ApiSerializer(Serializer\BasicDiscussionSerializer::class))
         ->attributes(AddDiscussionData::class),
 

--- a/extend.php
+++ b/extend.php
@@ -28,14 +28,14 @@ use FoF\Gamification\Notification\VoteBlueprint;
 
 return [
     (new Extend\Frontend('admin'))
-        ->css(__DIR__.'/resources/less/admin/extension.less')
-        ->js(__DIR__.'/js/dist/admin.js'),
+        ->css(__DIR__ . '/resources/less/admin/extension.less')
+        ->js(__DIR__ . '/js/dist/admin.js'),
     (new Extend\Frontend('forum'))
-        ->js(__DIR__.'/js/dist/forum.js')
-        ->css(__DIR__.'/resources/less/forum/extension.less')
+        ->js(__DIR__ . '/js/dist/forum.js')
+        ->css(__DIR__ . '/resources/less/forum/extension.less')
         ->route('/rankings', 'rankings'),
 
-    new Extend\Locales(__DIR__.'/resources/locale'),
+    new Extend\Locales(__DIR__ . '/resources/locale'),
 
     (new Extend\Model(User::class))
         ->belongsToMany('allVotes', User::class, 'user_id'),
@@ -132,6 +132,9 @@ return [
     (new Extend\ApiSerializer(Serializer\DiscussionSerializer::class))
         ->attributes(AddDiscussionData::class),
 
+    (new Extend\ApiSerializer(Serializer\BasicDiscussionSerializer::class))
+        ->attributes(AddDiscussionData::class),
+
     (new Extend\ApiSerializer(Serializer\PostSerializer::class))
         ->attributes(AddPostData::class),
 
@@ -189,5 +192,5 @@ return [
         ->command(Console\ResyncDiscussionVotes::class),
 
     (new Extend\View())
-        ->namespace('fof-gamification', __DIR__.'/resources/views'),
+        ->namespace('fof-gamification', __DIR__ . '/resources/views'),
 ];

--- a/extend.php
+++ b/extend.php
@@ -28,14 +28,14 @@ use FoF\Gamification\Notification\VoteBlueprint;
 
 return [
     (new Extend\Frontend('admin'))
-        ->css(__DIR__ . '/resources/less/admin/extension.less')
-        ->js(__DIR__ . '/js/dist/admin.js'),
+        ->css(__DIR__.'/resources/less/admin/extension.less')
+        ->js(__DIR__.'/js/dist/admin.js'),
     (new Extend\Frontend('forum'))
-        ->js(__DIR__ . '/js/dist/forum.js')
-        ->css(__DIR__ . '/resources/less/forum/extension.less')
+        ->js(__DIR__.'/js/dist/forum.js')
+        ->css(__DIR__.'/resources/less/forum/extension.less')
         ->route('/rankings', 'rankings'),
 
-    new Extend\Locales(__DIR__ . '/resources/locale'),
+    new Extend\Locales(__DIR__.'/resources/locale'),
 
     (new Extend\Model(User::class))
         ->belongsToMany('allVotes', User::class, 'user_id'),
@@ -192,5 +192,5 @@ return [
         ->command(Console\ResyncDiscussionVotes::class),
 
     (new Extend\View())
-        ->namespace('fof-gamification', __DIR__ . '/resources/views'),
+        ->namespace('fof-gamification', __DIR__.'/resources/views'),
 ];

--- a/src/AddDiscussionData.php
+++ b/src/AddDiscussionData.php
@@ -12,15 +12,11 @@
 namespace FoF\Gamification;
 
 use Flarum\Api\Serializer\BasicDiscussionSerializer;
-use Flarum\Api\Serializer\DiscussionSerializer;
 use Flarum\Discussion\Discussion;
 
 class AddDiscussionData
 {
-    /**
-     * @param DiscussionSerializer|BasicDiscussionSerializer $serializer
-     */
-    public function __invoke($serializer, Discussion $discussion, array $attributes): array
+    public function __invoke(BasicDiscussionSerializer $serializer, Discussion $discussion, array $attributes): array
     {
         $post = $discussion->firstPost ?: $discussion->posts()->where('number', 1)->first();
         $actor = $serializer->getActor();

--- a/src/AddDiscussionData.php
+++ b/src/AddDiscussionData.php
@@ -18,8 +18,6 @@ use Flarum\Discussion\Discussion;
 class AddDiscussionData
 {
     /**
-     * Undocumented function
-     *
      * @param DiscussionSerializer|BasicDiscussionSerializer $serializer
      */
     public function __invoke($serializer, Discussion $discussion, array $attributes): array

--- a/src/AddDiscussionData.php
+++ b/src/AddDiscussionData.php
@@ -11,12 +11,18 @@
 
 namespace FoF\Gamification;
 
+use Flarum\Api\Serializer\BasicDiscussionSerializer;
 use Flarum\Api\Serializer\DiscussionSerializer;
 use Flarum\Discussion\Discussion;
 
 class AddDiscussionData
 {
-    public function __invoke(DiscussionSerializer $serializer, Discussion $discussion, array $attributes): array
+    /**
+     * Undocumented function
+     *
+     * @param DiscussionSerializer|BasicDiscussionSerializer $serializer
+     */
+    public function __invoke($serializer, Discussion $discussion, array $attributes): array
     {
         $post = $discussion->firstPost ?: $discussion->posts()->where('number', 1)->first();
         $actor = $serializer->getActor();


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
When displaying the vote box next to discussions in the DiscussionList, sometimes vote info does not update when clicking to toggle a vote. This is because it pulls data from `discussion.votes` rather than `discussion.firstPost.votes`, while `UpdatePostController` (which handles the vote setting) only returns a basicly-serialized discussion as an included model in the API response, meaning that the vote count on the discussion itself does not get updated in the frontend.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
What performance impact does this bring? Is it significant?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
