### PR TITLE
Style for Load More rankings button

### DIFF
--- a/resources/less/forum/extension.less
+++ b/resources/less/forum/extension.less
@@ -213,3 +213,8 @@
     }
   }
 }
+
+.rankings-loadmore {
+  text-align: center;
+  margin-top: 10px;
+}


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
Style for Load More rankings button

**Screenshot**
Before
<img width="574" alt="Screenshot 2022-06-24 123821" src="https://user-images.githubusercontent.com/56961917/175469657-0bdeef2b-be31-4754-b00a-260c4d2d1f66.png">

After
<img width="433" alt="Screenshot 2022-06-24 123800" src="https://user-images.githubusercontent.com/56961917/175469661-e387d384-1903-413e-8782-075fa881ec37.png">

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
