### PR TITLE
Respect `seeVoters` permission while displaying voters widget in discussion sidebar

### DIFF
--- a/js/src/forum/addVotersToDiscussionPageSideBar.tsx
+++ b/js/src/forum/addVotersToDiscussionPageSideBar.tsx
@@ -13,7 +13,7 @@ export default function addVotersToDiscussionPageSideBar() {
     const posts = discussion.posts();
     const firstPost = posts[0];
 
-    if (firstPost?.canSeeVotes?.() && !!app.forum.attribute('fof-gamification-op-votes-only')) {
+    if (firstPost?.seeVoters?.() && !!app.forum.attribute('fof-gamification-op-votes-only')) {
       items.add('op-voters', <Voters post={firstPost} />, 90);
     }
   });


### PR DESCRIPTION
**Changes proposed in this pull request:**

Currently user can see this widget even if he do not have permissions to see voters list:

![08a80d8a](https://user-images.githubusercontent.com/5972388/183412476-d95fc78d-94fb-464a-8599-c12d1c0e5f4a.png)

After this PR this widget will respect "See who voted" permissions.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).