### PR TITLE
Fix post number condition in `Gamification::convertLike()`

### DIFF
--- a/src/Gamification.php
+++ b/src/Gamification.php
@@ -104,7 +104,7 @@ class Gamification
         if ($post && $post->user && $user) {
             Vote::updateUserVotes($post->user)->save();
 
-            if ($post->number = 1) {
+            if ($post->number === 1) {
                 Vote::updateDiscussionVotes($post->discussion);
             }
 


### PR DESCRIPTION
This looks like a typo. However the are other solutions that I do not understand:

1. In `AddVoteHandler` there are no such condition at all:
   https://github.com/FriendsOfFlarum/gamification/blob/eab4c033e2996012485881f14d7d5af83db54a4f/src/Listeners/AddVoteHandler.php#L49-L56
2. In `SaveVotesToDatabase` there is a different method to detect first post:
    https://github.com/FriendsOfFlarum/gamification/blob/c23465898270f4a5acbb5b86daba0b6950341020/src/Listeners/SaveVotesToDatabase.php#L167-L171
3. Why do we first calculate votes for discussions and users, and then add new vote? In that case calculations uses outdated votes list?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).