### PR TITLE
Auto Assigned Groups feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     ],
     "require": {
         "flarum/core": "^1.3.1",
-        "fof/extend": "^1.0.0"
+        "fof/extend": "^1.0.0",
+        "ext-json": "*"
     },
     "replace": {
         "reflar/gamification": "*"

--- a/extend.php
+++ b/extend.php
@@ -90,6 +90,7 @@ return [
         ->listen(Posted::class, Listeners\AddVoteHandler::class)
         ->listen(Deleted::class, Listeners\RemoveVoteHandler::class)
         ->listen(Started::class, Listeners\AddDiscussionVotes::class)
+        ->listen(Events\UserPointsUpdated::class, Listeners\UpdateAutoAssignedGroups::class)
         ->subscribe(Listeners\QueueJobs::class),
 
     (new Extend\ApiSerializer(Serializer\PostSerializer::class))
@@ -189,6 +190,7 @@ return [
         ->addFilter(Search\HotFilterGambit::class),
 
     (new Extend\Console())
+        ->command(Console\AutoAssignGroups::class)
         ->command(Console\ResyncDiscussionVotes::class),
 
     (new Extend\View())

--- a/js/src/admin/components/GroupSettings.tsx
+++ b/js/src/admin/components/GroupSettings.tsx
@@ -1,0 +1,149 @@
+import app from 'flarum/admin/app';
+import Component from 'flarum/common/Component';
+import Select from 'flarum/common/components/Select';
+import withAttr from 'flarum/common/utils/withAttr';
+import Stream from 'flarum/common/utils/Stream';
+import Group from 'flarum/common/models/Group';
+import Button from 'flarum/common/components/Button';
+
+interface SettingsEntry {
+  groupId?: number;
+  minPoints?: number;
+  maxPoints?: number;
+}
+
+interface GroupSettingsAttrs {
+  value: string;
+  onchange: (value: string) => void;
+}
+
+export default class GroupSettings extends Component<GroupSettingsAttrs> {
+  newGroupId = Stream('');
+  newMinPoints = Stream('');
+  newMaxPoints = Stream('');
+
+  view() {
+    let entries: SettingsEntry[] = [];
+
+    try {
+      entries = JSON.parse(this.attrs.value);
+    } catch (error) {
+      // silence errors. Will reset to empty array below
+    }
+
+    if (!Array.isArray(entries)) {
+      entries = [];
+    }
+
+    let groupOptions: { [id: string]: string } = {};
+
+    app.store.all<Group>('groups').forEach((group) => {
+      // Don't allow Member or Guest since those are virtual, and don't allow Admin as it's too dangerous and could strip admins of their roles
+      if ([Group.ADMINISTRATOR_ID, Group.MEMBER_ID, Group.GUEST_ID].indexOf(group.id()!) !== -1) {
+        return;
+      }
+
+      groupOptions[group.id()!] = group.nameSingular();
+    });
+
+    const addHandler = () => {
+      const newEntry: SettingsEntry = {
+        groupId: parseInt(this.newGroupId()),
+      };
+
+      if (this.newMinPoints()) {
+        newEntry.minPoints = parseInt(this.newMinPoints());
+      }
+
+      if (this.newMaxPoints()) {
+        newEntry.maxPoints = parseInt(this.newMaxPoints());
+      }
+
+      entries.push(newEntry);
+
+      this.attrs.onchange(JSON.stringify(entries));
+
+      this.newGroupId('');
+      this.newMinPoints('');
+      this.newMaxPoints('');
+    };
+
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th>Group</th>
+            <th>Minimum points (inclusive)</th>
+            <th>Maximum points (inclusive)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry, entryIndex) => {
+            const valueChangeHandler = (attribute: keyof SettingsEntry) => {
+              return (value: string) => {
+                if (value === '') {
+                  delete entry[attribute];
+                } else {
+                  entry[attribute] = parseInt(value);
+                }
+
+                this.attrs.onchange(JSON.stringify(entries));
+              };
+            };
+
+            const deleteHandler = () => {
+              entries.splice(entryIndex, 1);
+
+              this.attrs.onchange(JSON.stringify(entries));
+            };
+
+            return (
+              <tr>
+                <td>
+                  <Select options={groupOptions} value={entry.groupId + ''} onchange={valueChangeHandler('groupId')} />
+                </td>
+                <td>
+                  <input
+                    className="FormControl"
+                    type="number"
+                    value={entry.minPoints || ''}
+                    onchange={withAttr('value', valueChangeHandler('minPoints'))}
+                  />
+                </td>
+                <td>
+                  <input
+                    className="FormControl"
+                    type="number"
+                    value={entry.maxPoints || ''}
+                    onchange={withAttr('value', valueChangeHandler('maxPoints'))}
+                  />
+                </td>
+                <td>
+                  <Button className="Button Button--icon" icon="fas fa-times" onclick={deleteHandler}>
+                    Delete
+                  </Button>
+                </td>
+              </tr>
+            );
+          })}
+          <tr>
+            <td>
+              <Select options={groupOptions} value={this.newGroupId()} onchange={this.newGroupId} />
+            </td>
+            <td>
+              <input className="FormControl" type="number" bidi={this.newMinPoints} />
+            </td>
+            <td>
+              <input className="FormControl" type="number" bidi={this.newMaxPoints} />
+            </td>
+            <td>
+              <Button className="Button Button--icon" icon="fas fa-plus" onclick={addHandler} disabled={!this.newGroupId()}>
+                Add
+              </Button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    );
+  }
+}

--- a/js/src/admin/components/SettingsPage.js
+++ b/js/src/admin/components/SettingsPage.js
@@ -7,6 +7,7 @@ import withAttr from 'flarum/common/utils/withAttr';
 import Stream from 'flarum/common/utils/Stream';
 import ItemList from 'flarum/common/utils/ItemList';
 import UploadImageButton from './UploadImageButton';
+import GroupSettings from './GroupSettings';
 
 export default class SettingsPage extends ExtensionPage {
   oninit(vnode) {
@@ -21,6 +22,7 @@ export default class SettingsPage extends ExtensionPage {
       'iconName',
       'blockedUsers',
       'iconNameAlt',
+      'autoAssignedGroups',
     ];
 
     this.switches = [
@@ -273,6 +275,8 @@ export default class SettingsPage extends ExtensionPage {
       </>,
       70
     );
+
+    items.add('groups', <GroupSettings value={this.values.autoAssignedGroups()} onchange={this.values.autoAssignedGroups} />, 60);
 
     items.add(
       'submit',

--- a/src/Console/AutoAssignGroups.php
+++ b/src/Console/AutoAssignGroups.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace FoF\Gamification\Console;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\User;
+use FoF\Gamification\Jobs\AutoAssignUserGroups;
+use Illuminate\Console\Command;
+
+class AutoAssignGroups extends Command
+{
+    protected $signature = 'fof:gamification:assign-groups';
+    protected $description = 'Updates the auto-assigned groups of all users';
+
+    protected $totalAdded = 0;
+    protected $totalRemoved = 0;
+    protected $totalUsersUpdated = 0;
+
+    public function handle(SettingsRepositoryInterface $settings)
+    {
+        $this->output->progressStart(User::query()->count());
+
+        User::query()->each(function (User $user) use ($settings) {
+            $job = new AutoAssignUserGroups($user);
+            $job->handle($settings);
+
+            $this->totalAdded += $job->statsAdded;
+            $this->totalRemoved += $job->statsRemoved;
+
+            if ($job->statsAdded || $job->statsRemoved) {
+                $this->totalUsersUpdated++;
+            }
+
+            $this->output->progressAdvance();
+        });
+
+        $this->output->progressFinish();
+
+        $this->info("Updated {$this->totalUsersUpdated} users. Added {$this->totalAdded} groups and removed {$this->totalRemoved} groups");
+    }
+}

--- a/src/Console/AutoAssignGroups.php
+++ b/src/Console/AutoAssignGroups.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Gamification\Console;
 
 use Flarum\Settings\SettingsRepositoryInterface;

--- a/src/Jobs/AutoAssignUserGroups.php
+++ b/src/Jobs/AutoAssignUserGroups.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Gamification\Jobs;
 
 use Flarum\Group\Group;
@@ -36,7 +45,7 @@ class AutoAssignUserGroups
         $currentUserGroupIds = $this->user->groups->pluck('id');
 
         foreach ($entries as $entry) {
-            $id = (int)Arr::get($entry, 'groupId');
+            $id = (int) Arr::get($entry, 'groupId');
             $min = Arr::get($entry, 'minPoints');
             $max = Arr::get($entry, 'maxPoints');
 

--- a/src/Jobs/AutoAssignUserGroups.php
+++ b/src/Jobs/AutoAssignUserGroups.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace FoF\Gamification\Jobs;
+
+use Flarum\Group\Group;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\User;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+class AutoAssignUserGroups
+{
+    protected $user;
+    public $statsAdded = 0;
+    public $statsRemoved = 0;
+
+    public function __construct(User $user)
+    {
+        $this->user = $user;
+    }
+
+    public function handle(SettingsRepositoryInterface $settings)
+    {
+        $entries = json_decode($settings->get('fof-gamification.autoAssignedGroups'), true);
+
+        if (!is_array($entries)) {
+            return;
+        }
+
+        $groupsToAdd = [];
+        $groupsToRemove = [];
+
+        /**
+         * @var Collection $currentUserGroupIds
+         */
+        $currentUserGroupIds = $this->user->groups->pluck('id');
+
+        foreach ($entries as $entry) {
+            $id = (int)Arr::get($entry, 'groupId');
+            $min = Arr::get($entry, 'minPoints');
+            $max = Arr::get($entry, 'maxPoints');
+
+            // The UI doesn't offer admin, but we'll skip it here in case it was manually added in the database
+            // This way we never add or remove the admin group
+            // Also ignore the 2 virtual groups
+            if (in_array($id, [Group::ADMINISTRATOR_ID, Group::MEMBER_ID, Group::GUEST_ID])) {
+                continue;
+            }
+
+            $has = $currentUserGroupIds->contains($id);
+            // If an entry has min=null and max=null, it will never match, which is intentional as it allows "deprecating" a group that will be progressively removed
+            // Or removed in one go with the console command before deleting the rule entry
+            $shouldHave = !is_null($min) && $this->user->votes >= $min && (is_null($max) || $this->user->votes <= $max);
+
+            if ($has !== $shouldHave) {
+                if ($shouldHave) {
+                    $groupsToAdd[] = $id;
+                } else {
+                    $groupsToRemove[] = $id;
+                }
+            }
+        }
+
+        if ($this->statsAdded = count($groupsToAdd)) {
+            $this->user->groups()->attach($groupsToAdd);
+        }
+
+        if ($this->statsRemoved = count($groupsToRemove)) {
+            $this->user->groups()->detach($groupsToRemove);
+        }
+    }
+}

--- a/src/Listeners/UpdateAutoAssignedGroups.php
+++ b/src/Listeners/UpdateAutoAssignedGroups.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace FoF\Gamification\Listeners;
+
+use FoF\Gamification\Events\UserPointsUpdated;
+use FoF\Gamification\Jobs\AutoAssignUserGroups;
+use Illuminate\Contracts\Queue\Queue;
+
+class UpdateAutoAssignedGroups
+{
+    protected $queue;
+
+    public function __construct(Queue $queue)
+    {
+        $this->queue = $queue;
+    }
+
+    public function handle(UserPointsUpdated $event)
+    {
+        $this->queue->push(new AutoAssignUserGroups($event->user));
+    }
+}

--- a/src/Listeners/UpdateAutoAssignedGroups.php
+++ b/src/Listeners/UpdateAutoAssignedGroups.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Gamification\Listeners;
 
 use FoF\Gamification\Events\UserPointsUpdated;


### PR DESCRIPTION
**Changes proposed in this pull request:**
Add a new feature that allows auto-assigning (and removing) groups based on custom thresholds.

This feature is sponsored by a Blomstra client.

This still needs some translations.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
![image](https://user-images.githubusercontent.com/5264300/188332847-2cbe7ab7-1883-4ab8-8263-d235fe3a4900.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
