### PR TITLE
fix: multiple votes

### DIFF
--- a/migrations/2022_10_11_000000_add_user_constraints_to_votes_table.php
+++ b/migrations/2022_10_11_000000_add_user_constraints_to_votes_table.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        // Delete votes with non-existent users so that we will be able to create the new constraint.
+        $schema->getConnection()
+            ->table('post_votes')
+            ->whereNotExists(function ($query) {
+                $query->selectRaw(1)->from('users')->whereColumn('id', 'user_id');
+            })
+            ->delete();
+
+        $schema->table('post_votes', function (Blueprint $table) {
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    },
+    'down' => function (Builder $schema) {
+        $schema->table('post_votes', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+        });
+    },
+];

--- a/migrations/2022_10_11_000001_remove_duplicate_votes_and_apply_unique_index.php
+++ b/migrations/2022_10_11_000001_remove_duplicate_votes_and_apply_unique_index.php
@@ -21,12 +21,19 @@ return [
             ->havingRaw('COUNT(*) > 1')
             ->orderBy('id', 'desc')
             ->each(function ($row) use ($schema) {
+                $keep = $schema->getConnection()
+                    ->table('post_votes')
+                    ->where('user_id', $row->user_id)
+                    ->where('post_id', $row->post_id)
+                    ->orderBy('id', 'asc')
+                    ->first();
+
                 $schema->getConnection()
                     ->table('post_votes')
                     ->where('user_id', $row->user_id)
                     ->where('post_id', $row->post_id)
+                    ->where('id', '!=', $keep->id)
                     ->orderBy('id', 'desc')
-                    ->skip(1)
                     ->delete();
             });
 

--- a/migrations/2022_10_11_000001_remove_duplicate_votes_and_apply_unique_index.php
+++ b/migrations/2022_10_11_000001_remove_duplicate_votes_and_apply_unique_index.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        // Find duplicate votes based on `user_id` and `post_id` columns and delete them.
+        $schema->getConnection()
+            ->table('post_votes')
+            ->groupBy('user_id', 'post_id')
+            ->havingRaw('COUNT(*) > 1')
+            ->orderBy('id', 'desc')
+            ->each(function ($row) use ($schema) {
+                $schema->getConnection()
+                    ->table('post_votes')
+                    ->where('user_id', $row->user_id)
+                    ->where('post_id', $row->post_id)
+                    ->orderBy('id', 'desc')
+                    ->skip(1)
+                    ->delete();
+            });
+
+        $schema->table('post_votes', function (Blueprint $table) {
+            $table->unique(['post_id', 'user_id']);
+        });
+    },
+    'down' => function (Builder $schema) {
+        $schema->table('post_votes', function (Blueprint $table) {
+            $table->dropUnique(['post_id', 'user_id']);
+        });
+    },
+];


### PR DESCRIPTION
At present, it is possible to upvote a post multiple times from the same user. This PR:

- Removes votes from non existent users
- Adds a foriegn key to `user_id`
- Removes duplicate votes on a post from the same `user_id`
- Adds a unique index over `post_id` and `user_id`