### PR TITLE
Hide user votes if actor do not have permissions to see voters

### DIFF
--- a/src/Filter/VotedFilter.php
+++ b/src/Filter/VotedFilter.php
@@ -38,10 +38,13 @@ class VotedFilter implements FilterInterface
 
         $filterState
             ->getQuery()
-            ->whereIn('id', function ($query) use ($votedId, $negate) {
+            ->whereIn('id', function ($query) use ($votedId, $negate, $filterState) {
                 $query->select('post_id')
                     ->from('post_votes')
                     ->where('user_id', $negate ? '!=' : '=', $votedId);
+				if (!$filterState->getActor()->hasPermission('canSeeVoters')) {
+                    $query->where('user_id', '=', $filterState->getActor()->id);
+				}
             })
             ->when((bool) $this->settings->get('fof-gamification.firstPostOnly'), function ($query) {
                 $query->where('number', '1');


### PR DESCRIPTION
This was originally reported in https://github.com/FriendsOfFlarum/gamification/pull/85#issuecomment-1209824265

> Voters are also leaking on user profile - you can see posts user voted on even if you don't have permissions to see voters.

For example only me and people with `canSeeVoters` should see my votes on https://discuss.flarum.org/u/rob006/votes

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

