### PR TITLE
Prevent overlapping `.Post-actions` over `.EventPost` content

### DIFF
--- a/resources/less/forum/alternateLayout.less
+++ b/resources/less/forum/alternateLayout.less
@@ -178,7 +178,7 @@
   }
 }
 
-.Post-actions {
+.CommentPost .Post-actions {
   width: 100%;
   text-align: right;
 


### PR DESCRIPTION
Currently `.Post-actions` has 100% width also for even posts. This prevents accessing links in post event content, because `.Post-actions`  covers content. 

Before:

![816b089a](https://user-images.githubusercontent.com/5972388/219680217-44f93afa-8276-4761-8746-d6fea4a2ba63.png)

After:

![6e8376e8](https://user-images.githubusercontent.com/5972388/219680255-422ea3d7-5b8e-4db0-9241-d30111d25cd3.png)


**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

