### PR TITLE
Add `PostUser name` to  to `rankings-info`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^1.3.1",
+        "flarum/core": "^1.7",
         "fof/extend": "^1.0.0",
         "ext-json": "*"
     },

--- a/js/src/forum/addUserInfo.js
+++ b/js/src/forum/addUserInfo.js
@@ -11,10 +11,6 @@ export default function () {
     return (node) => node && node.attrs && node.attrs.className && String(node.attrs.className).split(' ').includes(className);
   };
 
-  const matchTag = (tagName) => {
-    return (node) => node && node.tag && node.tag === tagName;
-  };
-
   const findMatchClass = function (node, className) {
     const arr = [];
 
@@ -101,7 +97,7 @@ export default function () {
       return vnode;
     }
 
-    const header_node = vnode.children.find(matchTag('h3'));
+    const header_node = vnode.children.find(matchClass('PostUser-name'));
     const amt = Number(setting('rankAmt')) ?? user.ranks().length;
 
     header_node.children = header_node.children

--- a/js/src/forum/components/RankingsPage.js
+++ b/js/src/forum/components/RankingsPage.js
@@ -74,11 +74,11 @@ export default class RankingsPage extends Page {
                       )}
                       <td>
                         <div className="PostUser">
-                          <div className="PostUser-name rankings-info">
+                          <h3 className="PostUser-name rankings-info">
                             <Link href={app.route.user(user)} force={true}>
                               {i < 4 ? avatar(user, { className: 'info-avatar rankings-' + i + '-avatar' }) : ''} {username(user)}
                             </Link>
-                          </div>
+                          </h3>
                         </div>
                       </td>
                       {i < 4 ? <td className={'rankings-' + i}>{user.points()}</td> : <td className="rankings-4">{user.points()}</td>}

--- a/js/src/forum/components/RankingsPage.js
+++ b/js/src/forum/components/RankingsPage.js
@@ -74,11 +74,11 @@ export default class RankingsPage extends Page {
                       )}
                       <td>
                         <div className="PostUser">
-                          <h3 className="rankings-info">
+                          <div className="PostUser-name rankings-info">
                             <Link href={app.route.user(user)} force={true}>
                               {i < 4 ? avatar(user, { className: 'info-avatar rankings-' + i + '-avatar' }) : ''} {username(user)}
                             </Link>
-                          </h3>
+                          </div>
                         </div>
                       </td>
                       {i < 4 ? <td className={'rankings-' + i}>{user.points()}</td> : <td className="rankings-4">{user.points()}</td>}


### PR DESCRIPTION
Adjustments for https://github.com/flarum/framework/pull/3732

1. It uses class name instead of targeting h3 tag in `find()` call, so code should work after planned changes in Flarum 2.0.
2. I switched used tag from h3 to div - this was originally planed in core, but was postponed to 2.0 because of BC break. In case of this extension BC break should have much less impact than in core, so it may be OK to switch early to markup planned for Flarum 2.0.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
