### PR TITLE
fix: voters widget spins continiously when no voters

### DIFF
--- a/js/src/forum/components/Voters.tsx
+++ b/js/src/forum/components/Voters.tsx
@@ -51,7 +51,7 @@ export default class Voters extends Component<VotersAttrs> {
   }
 
   view() {
-    if (!this.attrs.post.votes() || !this.attrs.post.upvotes()) {
+    if (this.loading || !this.attrs.post.upvotes()) {
       return (
         <div className="VotingContainer">
           <div className="FoFGamification-voters">


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
