### PR TITLE
fix: prevent incorrect values on `firstPost` relationship of discussion list

### DIFF
--- a/src/AddPostData.php
+++ b/src/AddPostData.php
@@ -36,7 +36,7 @@ class AddPostData
         if ($canSeeVotes) {
             if ($actor->exists) {
                 /** @phpstan-ignore-next-line */
-                $vote = $post->actualvotes->first();
+                $vote = $post->actualvotes->firstWhere('user_id', $actor->id);
 
                 $attributes['hasUpvoted'] = $vote && $vote->isUpvote();
                 $attributes['hasDownvoted'] = $vote && $vote->isDownvote();


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #118**

**Changes proposed in this pull request:**
Ensure `hasUpvoted` and `hasDownvoted` are derived only from the current actor’s vote when serializing first posts on the discussions list. This prevents other users’ votes from being incorrectly picked up when the `actualvotes` relation is not fully constrained.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
