### PR TITLE
Fix SQLite migration: add default values for votes and hotness columns

### DIFF
--- a/migrations/2019_07_09_000002_add_votes_and_hotness_to_discussions.php
+++ b/migrations/2019_07_09_000002_add_votes_and_hotness_to_discussions.php
@@ -19,8 +19,8 @@ return [
         }
 
         $schema->table('discussions', function (Blueprint $table) {
-            $table->integer('votes');
-            $table->float('hotness', 10, 4);
+            $table->integer('votes')->default(0);
+            $table->float('hotness', 10, 4)->default(0);
         });
     },
     'down' => function (Builder $schema) {


### PR DESCRIPTION
## Summary
SQLite cannot add NOT NULL columns without default values to existing tables. The migration `2019_07_09_000002_add_votes_and_hotness_to_discussions` fails with:

```
Cannot add a NOT NULL column with default value NULL
```

This adds `->default(0)` to both `votes` and `hotness` columns, which is the logical default anyway (new discussions start with 0 votes and 0 hotness).