### PR TITLE
Fix saving vote for post/discussion created by deleted user

### DIFF
--- a/src/Listeners/SaveVotesToDatabase.php
+++ b/src/Listeners/SaveVotesToDatabase.php
@@ -96,7 +96,7 @@ class SaveVotesToDatabase
         }
     }
 
-    public function vote(Post $post, bool $isDownvoted, bool $isUpvoted, User $actor, User $user)
+    public function vote(Post $post, bool $isDownvoted, bool $isUpvoted, User $actor, ?User $user)
     {
         $vote = Vote::build($post, $actor);
 


### PR DESCRIPTION
This fixes an error when someone is trying to vote on discussion created by user, that was deleted.

<img width="424" height="194" alt="17540542" src="https://github.com/user-attachments/assets/4d598b44-86a8-4853-af0e-14ec8549d3ef" />


```
2026-03-18 13:59:23] flarum.ERROR: TypeError: Argument 5 passed to FoF\Gamification\Listeners\SaveVotesToDatabase::vote() must be an instance of Flarum\User\User, null given, called in /home/xxx/project/forum/vendor/fof/gamification/src/Listeners/SaveVotesToDatabase.php on line 94 and defined in /home/xxx/project/forum/vendor/fof/gamification/src/Listeners/SaveVotesToDatabase.php:99
Stack trace:
#0 /home/xxx/project/forum/vendor/fof/gamification/src/Listeners/SaveVotesToDatabase.php(94): FoF\Gamification\Listeners\SaveVotesToDatabase->vote()
#1 /home/xxx/project/forum/vendor/illuminate/events/Dispatcher.php(424): FoF\Gamification\Listeners\SaveVotesToDatabase->handle()

```