### PR TITLE
Fix PHPStan errors in search filters

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,8 +5,11 @@ parameters:
   level: 6
   paths:
     - extend.php
-    - vendor/flarum/likes/extend.php
     - src
+  scanFiles:
+    # Loaded for symbol resolution (we convert likes to upvotes) but not analysed:
+    # its optional flarum-realtime integration references classes we don't install.
+    - vendor/flarum/likes/extend.php
   excludePaths:
     - *.blade.php
   databaseMigrationsPath: ['migrations']

--- a/src/Filter/RankableFilter.php
+++ b/src/Filter/RankableFilter.php
@@ -11,11 +11,15 @@
 
 namespace FoF\Gamification\Filter;
 
+use Flarum\Search\Database\DatabaseSearchState;
 use Flarum\Search\Filter\FilterInterface;
 use Flarum\Search\SearchState;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\Exception\PermissionDeniedException;
 
+/**
+ * @implements FilterInterface<DatabaseSearchState>
+ */
 class RankableFilter implements FilterInterface
 {
     public function __construct(
@@ -36,7 +40,6 @@ class RankableFilter implements FilterInterface
 
         $blockedUsers = explode(', ', $this->settings->get('fof-gamification.blockedUsers'));
 
-        /** @phpstan-ignore-next-line */
         $state
             ->getQuery()
             ->whereIn('username', $blockedUsers, 'and', !$negate);

--- a/src/Filter/VotedFilter.php
+++ b/src/Filter/VotedFilter.php
@@ -11,10 +11,14 @@
 
 namespace FoF\Gamification\Filter;
 
+use Flarum\Search\Database\DatabaseSearchState;
 use Flarum\Search\Filter\FilterInterface;
 use Flarum\Search\SearchState;
 use Flarum\Settings\SettingsRepositoryInterface;
 
+/**
+ * @implements FilterInterface<DatabaseSearchState>
+ */
 class VotedFilter implements FilterInterface
 {
     public function __construct(
@@ -31,7 +35,6 @@ class VotedFilter implements FilterInterface
     {
         $votedId = trim($value, '"');
 
-        /** @phpstan-ignore-next-line */
         $state
             ->getQuery()
             ->whereIn('id', function ($query) use ($votedId, $negate, $state) {

--- a/src/Search/HotFilter.php
+++ b/src/Search/HotFilter.php
@@ -11,11 +11,15 @@
 
 namespace FoF\Gamification\Search;
 
+use Flarum\Search\Database\DatabaseSearchState;
 use Flarum\Search\Filter\FilterInterface;
 use Flarum\Search\SearchState;
 use Flarum\User\User;
-use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * @implements FilterInterface<DatabaseSearchState>
+ */
 class HotFilter implements FilterInterface
 {
     public function getFilterKey(): string
@@ -25,7 +29,6 @@ class HotFilter implements FilterInterface
 
     public function filter(SearchState $state, array|string $value, bool $negate): void
     {
-        /** @phpstan-ignore-next-line */
         $this->sort($state->getQuery(), $state->getActor(), $negate);
     }
 


### PR DESCRIPTION
## Summary

The PHPStan job on `2.x` is failing with 4 errors (unrelated to runtime — all DB test jobs pass). This fixes them properly instead of suppressing.

### Search filters — `getQuery()` undefined method

`getQuery()` is defined on `DatabaseSearchState`, not the base `SearchState` that `FilterInterface::filter()` declares. The filters relied on `@phpstan-ignore-next-line` comments that had drifted off the line they were meant to suppress.

These now declare `@implements FilterInterface<DatabaseSearchState>` — the same generic annotation Flarum core uses on its own filters (e.g. `AccessTokenTypeFilter`) — so PHPStan resolves `getQuery()` correctly. The fragile ignore comments are removed.

This also surfaced a genuine type error the old suppression was hiding: `HotFilter::sort()` typed its `$query` parameter as `Illuminate\Database\Query\Builder`, but `getQuery()` returns `Illuminate\Database\Eloquent\Builder`. Corrected the import and signature.

### `vendor/flarum/likes/extend.php` — Realtime class not found

This file was in PHPStan's analysed `paths`, but its `flarum-realtime` integration is optional (already gated at runtime via `whenExtensionEnabled`) and we don't install `flarum/realtime`. Moved it to `scanFiles` so PHPStan stays aware of it for symbol resolution but does not evaluate it.

PHPStan now reports no errors at level 6.