### PR TITLE
[2.x] fix: only force full-width post actions in the alternate vote layout

### DIFF
--- a/resources/less/forum/alternateLayout.less
+++ b/resources/less/forum/alternateLayout.less
@@ -150,7 +150,12 @@
   }
 }
 
-.CommentPost .Post-actions {
+// Only apply this when the actions row actually holds the absolute-positioned
+// vote box (the `useAlternateLayout` mode). Applying `width: 100%` to every
+// `.Post-actions` overrides core's `float: right` auto-width, so on the default
+// (inline) and side-column vote layouts it drops the likes/replies footer onto
+// its own line with a large gap. See flarum/framework#4765.
+.CommentPost .Post-actions:has(.CommentPost-votes.alternateLayout) {
   width: 100%;
   text-align: right;
 


### PR DESCRIPTION
### Problem

`alternateLayout.less` (imported unconditionally) applies `width: 100%` and `text-align: right` to **every** post's `.Post-actions`:

```less
.CommentPost .Post-actions {
  width: 100%;
  text-align: right;
  .CommentPost-votes.alternateLayout { position: absolute; left: 0; ... }
}
```

Flarum core lays out `.Post-actions` as `float: right` (auto width) so the Reply/Like row sits inline with the collapsed (`height: 0` inline-block) `.Post-footer` (likes/replies). Forcing `width: 100%` overrides that auto-width, so a full-width floated actions row can no longer share its line with the footer — the likes/replies line drops below with a large vertical gap.

This affects the two vote layouts that don't need the rule:
- **Default (inline votes)** — `<div class="CommentPost-votes">` in the actions row.
- **Side column (`altPostVotingUi`)** — votes are removed from the actions row and rendered in `.Post-side`.

The rule is only actually needed for the **`useAlternateLayout`** mode, where the vote box (`.CommentPost-votes.alternateLayout`) is absolutely positioned at `left: 0` inside the actions row and therefore needs a full-width container to anchor against.

Reported upstream at flarum/framework#4765 (same class of issue as the footer version fixed in FriendsOfFlarum/best-answer#133).

### Fix

Scope the rule to actions rows that actually contain the absolute vote box:

```less
.CommentPost .Post-actions:has(.CommentPost-votes.alternateLayout) {
  width: 100%;
  text-align: right;
  ...
}
```

- **Default / side-column layouts** → rule no longer matches → core's compact inline footer is restored.
- **`useAlternateLayout`** → the vote box is present in the actions row → rule still applies → layout unchanged.

### Notes

- Uses the CSS `:has()` selector (baseline across all current browsers since late 2023), consistent with Flarum 2.x's browser targets.
- CSS-only change; no compiled assets committed.

### Testing

Verified locally across all three vote layouts: default (inline) and side-column now render the tight inline footer; `useAlternateLayout` still positions the vote box correctly.