### PR TITLE
[2.x] perf: vote serialization and query overhaul

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -117,9 +117,13 @@ return [
             SortColumn::make('votes')
                 ->descendingAlias('votes'),
         ])
+        // The discussion's vote fields resolve through its first post, so load
+        // it and the actor's own vote on it for the whole page at once.
         ->endpoint('index', function (Endpoint\Index $endpoint) {
             return $endpoint->eagerLoadWhere('firstPost.actualvotes', function ($query, Context $context) {
-                $query->where('user_id', $context->getActor()->id);
+                // A guest has no votes to find; constraining on a null id
+                // would run the query anyway and match nothing.
+                $query->where('user_id', $context->getActor()->id ?? 0);
             });
         }),
 
@@ -129,9 +133,18 @@ return [
             return $endpoint->addDefaultInclude(['user.ranks']);
         })
         ->endpoint(['index', 'show', 'update'], function (Endpoint\Index|Endpoint\Show|Endpoint\Update $endpoint) {
-            return $endpoint->eagerLoadWhere('actualvotes', function ($query, Context $context) {
-                $query->where('user_id', $context->getActor()->id);
-            });
+            return $endpoint
+                ->eagerLoadWhere('actualvotes', function ($query, Context $context) {
+                    $query->where('user_id', $context->getActor()->id ?? 0);
+                })
+                // Each post serializes its discussion, whose own vote fields
+                // resolve through that discussion's first post. Without these
+                // the first post and its votes were fetched one discussion at
+                // a time.
+                ->eagerLoad('discussion.firstPost')
+                ->eagerLoadWhere('discussion.firstPost.actualvotes', function ($query, Context $context) {
+                    $query->where('user_id', $context->getActor()->id ?? 0);
+                });
         }),
 
     (new Extend\ApiResource(Resource\ForumResource::class))

--- a/src/Api/DiscussionResourceFields.php
+++ b/src/Api/DiscussionResourceFields.php
@@ -14,31 +14,74 @@ namespace FoF\Gamification\Api;
 use Flarum\Api\Context;
 use Flarum\Api\Schema;
 use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 
 class DiscussionResourceFields
 {
+    /**
+     * Per-discussion memo of the resolved first post, keyed by the discussion
+     * instance. Several fields need it and each used to resolve it
+     * independently, so a single discussion cost one query per field on top of
+     * the batched eager load.
+     *
+     * @var \WeakMap<Discussion, ?Post>
+     */
+    private \WeakMap $firstPosts;
+
+    public function __construct()
+    {
+        $this->firstPosts = new \WeakMap();
+    }
+
+    /**
+     * The discussion's first post: the eager-loaded relation where the index
+     * provided one, otherwise a lookup for a discussion whose first_post_id
+     * doesn't resolve (soft-deleted or renumbered posts).
+     */
+    private function firstPost(Discussion $discussion): ?Post
+    {
+        if (! isset($this->firstPosts[$discussion])) {
+            $post = $discussion->firstPost ?: $discussion->posts()->where('number', 1)->first();
+
+            // The post policies read $post->discussion, which would otherwise
+            // be lazy-loaded once per discussion in the list — re-fetching the
+            // very row being serialized. We already have it, so hand it over.
+            $post?->setRelation('discussion', $discussion);
+
+            $this->firstPosts[$discussion] = $post;
+        }
+
+        return $this->firstPosts[$discussion];
+    }
+
     public function __invoke(): array
     {
         return [
             Schema\Boolean::make('hasUpvoted')
                 ->visible($hasUpvotedVisible = function (Discussion $discussion, Context $context) {
-                    $postExists = $discussion->firstPost || $discussion->posts()->where('number', 1)->first();
+                    // Check the actor before touching the database: these
+                    // fields are never sent to a guest, and resolving the
+                    // first post to answer that cost one query per discussion
+                    // in the list for a result that was always false.
+                    if ($context->getActor()->isGuest() || ! $context->getActor()->exists) {
+                        return false;
+                    }
 
-                    return !$context->getActor()->isGuest() && $context->getActor()->exists && $postExists;
+                    return (bool) $this->firstPost($discussion);
                 })
                 ->get(function (Discussion $discussion, Context $context) {
-                    $post = $discussion->firstPost ?: $discussion->posts()->where('number', 1)->first();
+                    $post = $this->firstPost($discussion);
 
                     /** @phpstan-ignore-next-line */
-                    return $post->actualvotes->firstWhere('user_id', $context->getActor()->id)?->isUpvote() ?? false;
+                    return $post?->actualvotes->firstWhere('user_id', $context->getActor()->id)?->isUpvote() ?? false;
                 }),
             Schema\Boolean::make('hasDownvoted')
                 ->visible($hasUpvotedVisible)
                 ->get(function (Discussion $discussion, Context $context) {
-                    $post = $discussion->firstPost ?: $discussion->posts()->where('number', 1)->first();
+                    $post = $this->firstPost($discussion);
 
                     /** @phpstan-ignore-next-line */
-                    return $post->actualvotes->firstWhere('user_id', $context->getActor()->id)?->isDownvote() ?? false;
+                    return $post?->actualvotes->firstWhere('user_id', $context->getActor()->id)?->isDownvote() ?? false;
                 }),
             Schema\Number::make('votes')
                 ->visible(fn (Discussion $discussion, Context $context) => $context->getActor()->can('canSeeVotes', $discussion))
@@ -47,7 +90,7 @@ class DiscussionResourceFields
                 ->get(fn (Discussion $discussion, Context $context) => $context->getActor()->can('canSeeVotes', $discussion)),
             Schema\Boolean::make('canVote')
                 ->get(function (Discussion $discussion, Context $context) {
-                    $post = $discussion->firstPost ?: $discussion->posts()->where('number', 1)->first();
+                    $post = $this->firstPost($discussion);
 
                     return $post && $context->getActor()->can('votePosts', $discussion) && $context->getActor()->can('vote', $post);
                 }),

--- a/src/Api/DiscussionResourceFields.php
+++ b/src/Api/DiscussionResourceFields.php
@@ -40,7 +40,7 @@ class DiscussionResourceFields
      */
     private function firstPost(Discussion $discussion): ?Post
     {
-        if (! isset($this->firstPosts[$discussion])) {
+        if (!isset($this->firstPosts[$discussion])) {
             $post = $discussion->firstPost ?: $discussion->posts()->where('number', 1)->first();
 
             // The post policies read $post->discussion, which would otherwise
@@ -63,7 +63,7 @@ class DiscussionResourceFields
                     // fields are never sent to a guest, and resolving the
                     // first post to answer that cost one query per discussion
                     // in the list for a result that was always false.
-                    if ($context->getActor()->isGuest() || ! $context->getActor()->exists) {
+                    if ($context->getActor()->isGuest() || !$context->getActor()->exists) {
                         return false;
                     }
 

--- a/src/Api/DiscussionResourceFields.php
+++ b/src/Api/DiscussionResourceFields.php
@@ -24,7 +24,10 @@ class DiscussionResourceFields
      * independently, so a single discussion cost one query per field on top of
      * the batched eager load.
      *
-     * @var \WeakMap<Discussion, ?Post>
+     * WeakMap's value template is invariant, so it is not annotated with the
+     * narrowed value type; firstPost() declares what comes back out.
+     *
+     * @var \WeakMap<Discussion, mixed>
      */
     private \WeakMap $firstPosts;
 

--- a/src/Api/UserResourceFields.php
+++ b/src/Api/UserResourceFields.php
@@ -16,6 +16,14 @@ use Flarum\User\User;
 
 class UserResourceFields
 {
+    /**
+     * Cached answers to canHaveVotingNotifications, keyed by the user's set of
+     * group ids — the only thing the answer depends on.
+     *
+     * @var array<string, bool>
+     */
+    private array $votingNotifications = [];
+
     public function __invoke(): array
     {
         return [
@@ -23,7 +31,13 @@ class UserResourceFields
                 ->property('votes'),
             Schema\Boolean::make('canHaveVotingNotifications')
                 ->get(function (User $user) {
-                    return $user->hasPermission('discussion.upvote_notifications')
+                    // Asked of every user in a listing, and the answer depends
+                    // only on their groups — so users who share a set of groups
+                    // share an answer. Without this, a page of users re-ran the
+                    // same permission lookup for each of them.
+                    $groups = $user->groups->pluck('id')->sort()->implode(',');
+
+                    return $this->votingNotifications[$groups] ??= $user->hasPermission('discussion.upvote_notifications')
                         || $user->hasPermission('discussion.downvote_notifications');
                 }),
 

--- a/tests/integration/api/VoteQueryCountTest.php
+++ b/tests/integration/api/VoteQueryCountTest.php
@@ -43,7 +43,7 @@ class VoteQueryCountTest extends EnhancedTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->extension('fof-gamification');
+        $this->extension(...(getenv('NOGAM') ? [] : ['fof-gamification']));
 
         $now = Carbon::now()->toDateTimeString();
         $users = [$this->normalUser()];
@@ -101,6 +101,12 @@ class VoteQueryCountTest extends EnhancedTestCase
     public function probe_posts_member()
     {
         $this->assertSame(200, $this->get('/api/posts?filter[discussion]=1', 3));
+    }
+
+    #[Test]
+    public function probe_users_member()
+    {
+        $this->assertSame(200, $this->get('/api/users', 3));
     }
 
     #[Test]

--- a/tests/integration/api/VoteQueryCountTest.php
+++ b/tests/integration/api/VoteQueryCountTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Gamification\Tests\integration\api;
 
 use Carbon\Carbon;
@@ -55,28 +64,48 @@ class VoteQueryCountTest extends EnhancedTestCase
         }
 
         $this->prepareDatabase([
-            User::class => $users,
-            Group::class => [['id' => 101, 'name_singular' => 'V', 'name_plural' => 'V']],
-            'group_user' => [['user_id' => 3, 'group_id' => 101]],
+            User::class        => $users,
+            Group::class       => [['id' => 101, 'name_singular' => 'V', 'name_plural' => 'V']],
+            'group_user'       => [['user_id' => 3, 'group_id' => 101]],
             'group_permission' => [
                 ['group_id' => 101, 'permission' => 'discussion.canSeeVotes'],
                 ['group_id' => 101, 'permission' => 'discussion.canSeeVoters'],
                 ['group_id' => 101, 'permission' => 'discussion.votePosts'],
             ],
             Discussion::class => $discussions,
-            Post::class => $posts,
-            'post_votes' => $votes,
+            Post::class       => $posts,
+            'post_votes'      => $votes,
         ]);
     }
 
     private function get(string $uri, ?int $actor = null): int
     {
         $options = $actor !== null ? ['authenticatedAs' => $actor] : [];
+
         return $this->send($this->request('GET', $uri, $options))->getStatusCode();
     }
 
-    #[Test] public function probe_index_member() { $this->assertSame(200, $this->get('/api/discussions', 3)); }
-    #[Test] public function probe_index_guest() { $this->assertSame(200, $this->get('/api/discussions')); }
-    #[Test] public function probe_posts_member() { $this->assertSame(200, $this->get('/api/posts?filter[discussion]=1', 3)); }
-    #[Test] public function probe_posts_guest() { $this->assertSame(200, $this->get('/api/posts?filter[discussion]=1')); }
+    #[Test]
+    public function probe_index_member()
+    {
+        $this->assertSame(200, $this->get('/api/discussions', 3));
+    }
+
+    #[Test]
+    public function probe_index_guest()
+    {
+        $this->assertSame(200, $this->get('/api/discussions'));
+    }
+
+    #[Test]
+    public function probe_posts_member()
+    {
+        $this->assertSame(200, $this->get('/api/posts?filter[discussion]=1', 3));
+    }
+
+    #[Test]
+    public function probe_posts_guest()
+    {
+        $this->assertSame(200, $this->get('/api/posts?filter[discussion]=1'));
+    }
 }

--- a/tests/integration/api/VoteQueryCountTest.php
+++ b/tests/integration/api/VoteQueryCountTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace FoF\Gamification\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Group\Group;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\User\User;
+use FoF\Gamification\Tests\EnhancedTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards the endpoints this extension extends against per-record queries.
+ *
+ * The rest of the suite works with a single discussion, where an N+1 is
+ * indistinguishable from a single query. These requests run against enough
+ * records that a per-record pattern is visible, and flarum/testing's
+ * repeated-query detector fails the test if one appears.
+ *
+ * All three of these were real: the discussion list resolved each
+ * discussion's first post (and re-fetched the discussion itself through the
+ * post policy) one row at a time, and the posts endpoint did the same for
+ * every discussion it serialized alongside its posts.
+ */
+class VoteQueryCountTest extends EnhancedTestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    private const DISCUSSIONS = 10;
+    private const VOTERS = 5;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->extension('fof-gamification');
+
+        $now = Carbon::now()->toDateTimeString();
+        $users = [$this->normalUser()];
+        for ($u = 3; $u < 3 + self::VOTERS; $u++) {
+            $users[] = ['id' => $u, 'username' => "voter$u", 'email' => "voter$u@machine.local", 'is_email_confirmed' => 1];
+        }
+
+        $discussions = $posts = $votes = [];
+        $voteId = 1;
+        for ($d = 1; $d <= self::DISCUSSIONS; $d++) {
+            $fp = $d * 10;
+            $discussions[] = ['id' => $d, 'title' => "D$d", 'created_at' => $now, 'last_posted_at' => $now, 'user_id' => 2, 'first_post_id' => $fp, 'comment_count' => 2, 'is_private' => 0, 'votes' => self::VOTERS];
+            $posts[] = ['id' => $fp, 'discussion_id' => $d, 'number' => 1, 'created_at' => $now, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>first</p></t>'];
+            $posts[] = ['id' => $fp + 1, 'discussion_id' => $d, 'number' => 2, 'created_at' => $now, 'user_id' => 3, 'type' => 'comment', 'content' => '<t><p>reply</p></t>'];
+            for ($u = 3; $u < 3 + self::VOTERS; $u++) {
+                $votes[] = ['id' => $voteId++, 'post_id' => $fp, 'user_id' => $u, 'value' => 1];
+            }
+        }
+
+        $this->prepareDatabase([
+            User::class => $users,
+            Group::class => [['id' => 101, 'name_singular' => 'V', 'name_plural' => 'V']],
+            'group_user' => [['user_id' => 3, 'group_id' => 101]],
+            'group_permission' => [
+                ['group_id' => 101, 'permission' => 'discussion.canSeeVotes'],
+                ['group_id' => 101, 'permission' => 'discussion.canSeeVoters'],
+                ['group_id' => 101, 'permission' => 'discussion.votePosts'],
+            ],
+            Discussion::class => $discussions,
+            Post::class => $posts,
+            'post_votes' => $votes,
+        ]);
+    }
+
+    private function get(string $uri, ?int $actor = null): int
+    {
+        $options = $actor !== null ? ['authenticatedAs' => $actor] : [];
+        return $this->send($this->request('GET', $uri, $options))->getStatusCode();
+    }
+
+    #[Test] public function probe_index_member() { $this->assertSame(200, $this->get('/api/discussions', 3)); }
+    #[Test] public function probe_index_guest() { $this->assertSame(200, $this->get('/api/discussions')); }
+    #[Test] public function probe_posts_member() { $this->assertSame(200, $this->get('/api/posts?filter[discussion]=1', 3)); }
+    #[Test] public function probe_posts_guest() { $this->assertSame(200, $this->get('/api/posts?filter[discussion]=1')); }
+}

--- a/tests/integration/api/VoteVisibilityCharacterisationTest.php
+++ b/tests/integration/api/VoteVisibilityCharacterisationTest.php
@@ -1,0 +1,321 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Gamification\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Group\Group;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\User\User;
+use FoF\Gamification\Tests\EnhancedTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Pins the serialized vote fields across the setting/permission/actor matrix.
+ *
+ * This extension's visible behaviour is the product of several independent
+ * switches — `firstPostOnly`, `allowSelfVotes`, three separate permissions, and
+ * whether the actor is a guest, the post's author, or someone else — and the
+ * fields are resolved in serializer callbacks and a policy rather than in one
+ * place. That makes it easy to change the payload by accident while optimising.
+ *
+ * These tests therefore assert what the extension does *today*, so any change
+ * to the observable API is a deliberate decision rather than a side effect. If
+ * one of these fails, the payload changed: establish whether that was intended
+ * before updating the expectation.
+ *
+ * The two permissions are deliberately distinct and are pinned separately:
+ *   - canSeeVotes  — "See up/down vote count"  (the tally)
+ *   - canSeeVoters — "See who voted"           (the identities)
+ * Holding one without the other is a legitimate configuration.
+ */
+class VoteVisibilityCharacterisationTest extends EnhancedTestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    private const AUTHOR = 2;   // wrote both posts
+    private const OTHER = 3;    // another member, upvoted the first post
+    private const VOTER_GROUP = 101;
+
+    private const FIRST_POST = 1;
+    private const REPLY = 2;
+
+    /**
+     * @param array<string, mixed> $settings
+     * @param string[]|null        $permissions permissions granted to the voter
+     *                                          group; null grants all three
+     */
+    private function boot(array $settings = [], ?array $permissions = null): void
+    {
+        // Settings must be staged before anything boots the app.
+        foreach ($settings as $key => $value) {
+            $this->setting($key, $value);
+        }
+
+        $this->extension('fof-gamification');
+
+        $now = Carbon::now()->toDateTimeString();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(), // id 2
+                ['id' => 3, 'username' => 'other', 'email' => 'other@machine.local', 'is_email_confirmed' => 1],
+            ],
+            Group::class => [
+                ['id' => self::VOTER_GROUP, 'name_singular' => 'Voter', 'name_plural' => 'Voters'],
+            ],
+            'group_user' => [
+                ['user_id' => 2, 'group_id' => self::VOTER_GROUP],
+                ['user_id' => 3, 'group_id' => self::VOTER_GROUP],
+            ],
+            'group_permission' => array_map(
+                fn (string $permission) => ['group_id' => self::VOTER_GROUP, 'permission' => $permission],
+                $permissions ?? ['discussion.canSeeVotes', 'discussion.canSeeVoters', 'discussion.votePosts']
+            ),
+            Discussion::class => [
+                ['id' => 1, 'title' => 'D', 'created_at' => $now, 'last_posted_at' => $now, 'user_id' => self::AUTHOR, 'first_post_id' => 1, 'comment_count' => 2, 'is_private' => 0, 'votes' => 1],
+            ],
+            Post::class => [
+                ['id' => self::FIRST_POST, 'discussion_id' => 1, 'number' => 1, 'created_at' => $now, 'user_id' => self::AUTHOR, 'type' => 'comment', 'content' => '<t><p>first</p></t>'],
+                ['id' => self::REPLY, 'discussion_id' => 1, 'number' => 2, 'created_at' => $now, 'user_id' => self::AUTHOR, 'type' => 'comment', 'content' => '<t><p>reply</p></t>'],
+            ],
+            'post_votes' => [
+                ['id' => 1, 'post_id' => self::FIRST_POST, 'user_id' => self::OTHER, 'value' => 1],
+            ],
+        ]);
+    }
+
+    /** @return array<string, mixed> the discussion's serialized attributes */
+    private function discussion(?int $actor): array
+    {
+        $options = $actor !== null ? ['authenticatedAs' => $actor] : [];
+
+        $response = $this->send($this->request('GET', '/api/discussions', $options));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        return $body['data'][0]['attributes'] ?? [];
+    }
+
+    /** @return array<int, array<string, mixed>> post id => serialized attributes */
+    private function posts(?int $actor): array
+    {
+        $options = $actor !== null ? ['authenticatedAs' => $actor] : [];
+
+        $response = $this->send($this->request('GET', '/api/posts?filter[discussion]=1', $options));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $posts = [];
+        foreach ($body['data'] ?? [] as $row) {
+            $posts[(int) $row['id']] = $row['attributes'];
+        }
+
+        return $posts;
+    }
+
+    // ---------------------------------------------------------------------
+    // Guests
+    // ---------------------------------------------------------------------
+
+    #[Test]
+    public function a_guest_sees_no_vote_state_on_the_discussion_list()
+    {
+        $this->boot();
+
+        $attributes = $this->discussion(null);
+
+        // hasUpvoted/hasDownvoted/votes are omitted entirely for guests, while
+        // seeVotes and canVote are present and false. Optimising the guest path
+        // must preserve this exact shape — the frontend reads canVote to decide
+        // whether to show a control that prompts for login.
+        $this->assertArrayNotHasKey('hasUpvoted', $attributes);
+        $this->assertArrayNotHasKey('hasDownvoted', $attributes);
+        $this->assertArrayNotHasKey('votes', $attributes);
+        $this->assertFalse($attributes['seeVotes']);
+        $this->assertFalse($attributes['canVote']);
+    }
+
+    #[Test]
+    public function a_guest_sees_no_vote_state_on_posts()
+    {
+        $this->boot();
+
+        foreach ($this->posts(null) as $id => $attributes) {
+            $this->assertFalse($attributes['canSeeVotes'], "post $id");
+            $this->assertFalse($attributes['canVote'], "post $id");
+            $this->assertFalse($attributes['seeVoters'], "post $id");
+            $this->assertArrayNotHasKey('votes', $attributes, "post $id");
+            $this->assertArrayNotHasKey('hasUpvoted', $attributes, "post $id");
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Defaults: firstPostOnly = true, allowSelfVotes = true
+    // ---------------------------------------------------------------------
+
+    #[Test]
+    public function by_default_only_the_first_post_carries_vote_state()
+    {
+        $this->boot();
+
+        $posts = $this->posts(self::OTHER);
+
+        $this->assertTrue($posts[self::FIRST_POST]['canSeeVotes']);
+        $this->assertTrue($posts[self::FIRST_POST]['canVote']);
+        $this->assertSame(1, $posts[self::FIRST_POST]['votes']);
+        $this->assertTrue($posts[self::FIRST_POST]['hasUpvoted']);
+
+        // firstPostOnly denies the reply outright, so its vote fields are
+        // hidden rather than false-valued.
+        $this->assertFalse($posts[self::REPLY]['canSeeVotes']);
+        $this->assertFalse($posts[self::REPLY]['canVote']);
+        $this->assertArrayNotHasKey('votes', $posts[self::REPLY]);
+        $this->assertArrayNotHasKey('hasUpvoted', $posts[self::REPLY]);
+    }
+
+    #[Test]
+    public function the_discussion_reflects_the_actors_own_vote()
+    {
+        $this->boot();
+
+        $voted = $this->discussion(self::OTHER);
+        $this->assertTrue($voted['hasUpvoted']);
+        $this->assertFalse($voted['hasDownvoted']);
+        $this->assertSame(1, $voted['votes']);
+
+        // The author has not voted; the count is the same for both.
+        $notVoted = $this->discussion(self::AUTHOR);
+        $this->assertFalse($notVoted['hasUpvoted']);
+        $this->assertFalse($notVoted['hasDownvoted']);
+        $this->assertSame(1, $notVoted['votes']);
+    }
+
+    // ---------------------------------------------------------------------
+    // firstPostOnly = false
+    // ---------------------------------------------------------------------
+
+    #[Test]
+    public function disabling_first_post_only_exposes_vote_state_on_replies()
+    {
+        $this->boot(['fof-gamification.firstPostOnly' => 0]);
+
+        $posts = $this->posts(self::OTHER);
+
+        $this->assertTrue($posts[self::REPLY]['canSeeVotes']);
+        $this->assertTrue($posts[self::REPLY]['canVote']);
+        $this->assertTrue($posts[self::REPLY]['seeVoters']);
+        // The reply has no votes at all, which serializes as null (not 0).
+        $this->assertNull($posts[self::REPLY]['votes']);
+        $this->assertFalse($posts[self::REPLY]['hasUpvoted']);
+    }
+
+    // ---------------------------------------------------------------------
+    // allowSelfVotes = false
+    // ---------------------------------------------------------------------
+
+    #[Test]
+    public function disabling_self_votes_only_blocks_the_posts_own_author()
+    {
+        $this->boot(['fof-gamification.allowSelfVotes' => 0]);
+
+        $author = $this->posts(self::AUTHOR);
+        $other = $this->posts(self::OTHER);
+
+        // The author wrote the first post, so cannot vote on it — but can still
+        // see the count.
+        $this->assertFalse($author[self::FIRST_POST]['canVote']);
+        $this->assertTrue($author[self::FIRST_POST]['canSeeVotes']);
+
+        // Everyone else is unaffected.
+        $this->assertTrue($other[self::FIRST_POST]['canVote']);
+
+        // The discussion-level canVote follows the same rule, since it resolves
+        // through the first post.
+        $this->assertFalse($this->discussion(self::AUTHOR)['canVote']);
+        $this->assertTrue($this->discussion(self::OTHER)['canVote']);
+    }
+
+    #[Test]
+    public function self_votes_are_allowed_by_default()
+    {
+        $this->boot();
+
+        $this->assertTrue($this->posts(self::AUTHOR)[self::FIRST_POST]['canVote']);
+        $this->assertTrue($this->discussion(self::AUTHOR)['canVote']);
+    }
+
+    // ---------------------------------------------------------------------
+    // Permissions, pinned independently
+    // ---------------------------------------------------------------------
+
+    #[Test]
+    public function can_see_votes_alone_exposes_the_count_but_not_the_voters()
+    {
+        $this->boot(permissions: ['discussion.canSeeVotes']);
+
+        $post = $this->posts(self::OTHER)[self::FIRST_POST];
+
+        $this->assertTrue($post['canSeeVotes']);
+        $this->assertSame(1, $post['votes']);
+        $this->assertFalse($post['seeVoters'], 'canSeeVotes must not imply canSeeVoters');
+    }
+
+    #[Test]
+    public function can_see_voters_is_what_exposes_the_voter_identities()
+    {
+        $this->boot(permissions: ['discussion.canSeeVotes', 'discussion.canSeeVoters']);
+
+        $this->assertTrue($this->posts(self::OTHER)[self::FIRST_POST]['seeVoters']);
+    }
+
+    #[Test]
+    public function vote_permissions_can_be_scoped_to_a_tag()
+    {
+        // discuss.flarum.org grants the three vote permissions only as
+        // `tag<id>.discussion.*`, so voting is enabled in one tag and nowhere
+        // else. The global permission is absent entirely: an actor's access
+        // therefore depends on the discussion's tags, not just their groups.
+        // Pinned because a policy or eager-loading change could easily start
+        // consulting the global permission instead.
+        $this->boot(permissions: ['tag99.discussion.canSeeVotes', 'tag99.discussion.canSeeVoters']);
+
+        $post = $this->posts(self::OTHER)[self::FIRST_POST];
+
+        // The fixture discussion carries no tags, so a tag-scoped grant must
+        // not leak into it.
+        $this->assertFalse($post['canSeeVotes'], 'a tag-scoped grant must not apply to an untagged discussion');
+        $this->assertFalse($post['seeVoters']);
+    }
+
+    #[Test]
+    public function withholding_can_see_votes_hides_the_count_but_not_the_ability_to_vote()
+    {
+        // votePosts is granted to Members by default, so an actor can still be
+        // entitled to vote while unable to see the tally — a legitimate
+        // configuration, and the frontend disables the buttons accordingly.
+        $this->boot(permissions: ['discussion.votePosts']);
+
+        $discussion = $this->discussion(self::OTHER);
+        $post = $this->posts(self::OTHER)[self::FIRST_POST];
+
+        $this->assertFalse($discussion['seeVotes']);
+        $this->assertArrayNotHasKey('votes', $discussion);
+        $this->assertFalse($post['canSeeVotes']);
+        $this->assertArrayNotHasKey('votes', $post);
+
+        $this->assertTrue($post['canVote']);
+    }
+}

--- a/tests/integration/api/VoteWritePathTest.php
+++ b/tests/integration/api/VoteWritePathTest.php
@@ -1,0 +1,313 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Gamification\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Group\Group;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\User\User;
+use FoF\Gamification\Tests\EnhancedTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Pins what casting a vote actually changes.
+ *
+ * Nothing in the suite cast a vote before this: every test read pre-seeded
+ * rows. That left the whole write path unprotected — a single vote updates the
+ * vote row, the author's running total, the discussion's tally and hotness,
+ * and the author's ranks, then dispatches events that drive notifications and
+ * auto-assigned groups. A wrong change here corrupts scores silently rather
+ * than raising an error, which is exactly the kind of failure a test suite has
+ * to catch.
+ *
+ * As with the visibility tests, these assert what the extension does *today*.
+ */
+class VoteWritePathTest extends EnhancedTestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    private const AUTHOR = 2;
+    private const VOTER = 3;
+    private const OTHER_VOTER = 4;
+    private const VOTER_GROUP = 101;
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    private function boot(array $settings = []): void
+    {
+        foreach ($settings as $key => $value) {
+            $this->setting($key, $value);
+        }
+
+        $this->extension('fof-gamification');
+
+        $now = Carbon::now()->toDateTimeString();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(), // id 2, the author
+                ['id' => 3, 'username' => 'voter', 'email' => 'voter@machine.local', 'is_email_confirmed' => 1],
+                ['id' => 4, 'username' => 'voter2', 'email' => 'voter2@machine.local', 'is_email_confirmed' => 1],
+            ],
+            Group::class => [
+                ['id' => self::VOTER_GROUP, 'name_singular' => 'Voter', 'name_plural' => 'Voters'],
+            ],
+            'group_user' => [
+                ['user_id' => 2, 'group_id' => self::VOTER_GROUP],
+                ['user_id' => 3, 'group_id' => self::VOTER_GROUP],
+                ['user_id' => 4, 'group_id' => self::VOTER_GROUP],
+            ],
+            'group_permission' => [
+                ['group_id' => self::VOTER_GROUP, 'permission' => 'discussion.votePosts'],
+                ['group_id' => self::VOTER_GROUP, 'permission' => 'discussion.canSeeVotes'],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'D', 'created_at' => $now, 'last_posted_at' => $now, 'user_id' => self::AUTHOR, 'first_post_id' => 1, 'comment_count' => 2, 'is_private' => 0],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'created_at' => $now, 'user_id' => self::AUTHOR, 'type' => 'comment', 'content' => '<t><p>first</p></t>'],
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'created_at' => $now, 'user_id' => self::AUTHOR, 'type' => 'comment', 'content' => '<t><p>reply</p></t>'],
+            ],
+            'ranks' => [
+                ['id' => 1, 'points' => 1, 'name' => 'Rookie', 'color' => '#ffffff'],
+                ['id' => 2, 'points' => 5, 'name' => 'Pro', 'color' => '#000000'],
+            ],
+        ]);
+    }
+
+    /**
+     * The write path reloads the same user several times within one request —
+     * the vote handler, the points update and the rank sync each work from
+     * their own instance. It is a real inefficiency, measured but deliberately
+     * not fixed here: these tests exist to pin behaviour first, so that the
+     * write path can be optimised against them afterwards.
+     */
+    protected function allowedRepeatedQueries(): array
+    {
+        return ['select * from "users" where "users"."id" = ?'];
+    }
+
+    private function vote(int $actor, ?string $value, int $postId = 1): int
+    {
+        return $this->send(
+            $this->request('PATCH', "/api/posts/$postId", [
+                'authenticatedAs' => $actor,
+                'json'            => ['data' => ['attributes' => ['vote' => $value]]],
+            ])
+        )->getStatusCode();
+    }
+
+    private function discussionRow(): object
+    {
+        return $this->database()->table('discussions')->where('id', 1)->first();
+    }
+
+    private function authorVotes(): int
+    {
+        return (int) $this->database()->table('users')->where('id', self::AUTHOR)->value('votes');
+    }
+
+    /** @return array<int, int> user id => vote value */
+    private function voteRows(int $postId = 1): array
+    {
+        return $this->database()->table('post_votes')->where('post_id', $postId)
+            ->pluck('value', 'user_id')->map(fn ($v) => (int) $v)->all();
+    }
+
+    /** @return int[] */
+    private function authorRankIds(): array
+    {
+        return $this->database()->table('rank_users')->where('user_id', self::AUTHOR)
+            ->pluck('rank_id')->map(fn ($id) => (int) $id)->sort()->values()->all();
+    }
+
+    #[Test]
+    public function an_upvote_records_the_vote_and_updates_every_tally()
+    {
+        $this->boot();
+
+        $this->assertSame(200, $this->vote(self::VOTER, 'up'));
+
+        $this->assertSame([self::VOTER => 1], $this->voteRows());
+        $this->assertSame(1, $this->authorVotes(), "the author's running total");
+        $this->assertSame(1, (int) $this->discussionRow()->votes, 'the discussion tally');
+    }
+
+    #[Test]
+    public function voting_the_same_way_twice_is_idempotent()
+    {
+        $this->boot();
+
+        $this->vote(self::VOTER, 'up');
+        $this->assertSame(200, $this->vote(self::VOTER, 'up'));
+
+        // One row, not two, and no double-counting.
+        $this->assertSame([self::VOTER => 1], $this->voteRows());
+        $this->assertSame(1, $this->authorVotes());
+        $this->assertSame(1, (int) $this->discussionRow()->votes);
+    }
+
+    #[Test]
+    public function switching_from_up_to_down_swings_the_tally_by_two()
+    {
+        $this->boot();
+
+        $this->vote(self::VOTER, 'up');
+        $this->assertSame(200, $this->vote(self::VOTER, 'down'));
+
+        $this->assertSame([self::VOTER => -1], $this->voteRows());
+        $this->assertSame(-1, $this->authorVotes());
+        $this->assertSame(-1, (int) $this->discussionRow()->votes);
+    }
+
+    #[Test]
+    public function clearing_a_vote_zeroes_the_row_rather_than_deleting_it()
+    {
+        $this->boot();
+
+        $this->vote(self::VOTER, 'up');
+        $this->assertSame(200, $this->vote(self::VOTER, null));
+
+        // The row survives with value 0 — worth pinning, because anything that
+        // reasons about "has this user voted" by row existence rather than by
+        // value would read this as a vote.
+        $this->assertSame([self::VOTER => 0], $this->voteRows());
+        $this->assertSame(0, $this->authorVotes());
+        $this->assertSame(0, (int) $this->discussionRow()->votes);
+    }
+
+    #[Test]
+    public function votes_from_several_users_accumulate()
+    {
+        $this->boot();
+
+        $this->vote(self::VOTER, 'up');
+        $this->vote(self::OTHER_VOTER, 'up');
+
+        $this->assertSame([self::VOTER => 1, self::OTHER_VOTER => 1], $this->voteRows());
+        $this->assertSame(2, $this->authorVotes());
+        $this->assertSame(2, (int) $this->discussionRow()->votes);
+    }
+
+    #[Test]
+    public function the_author_gains_a_rank_on_reaching_its_points_and_loses_it_again()
+    {
+        $this->boot();
+
+        $this->assertSame([], $this->authorRankIds(), 'no ranks before any votes');
+
+        $this->vote(self::VOTER, 'up');
+        $this->assertSame([1], $this->authorRankIds(), 'the 1-point rank is granted');
+
+        // Ranks are re-synced from the running total, so they are revoked when
+        // the total falls back below the threshold.
+        $this->vote(self::VOTER, 'down');
+        $this->assertSame([], $this->authorRankIds(), 'and revoked when points drop');
+    }
+
+    #[Test]
+    public function hotness_tracks_the_discussion_tally()
+    {
+        $this->boot();
+
+        $this->assertSame(0.0, (float) $this->discussionRow()->hotness);
+
+        $this->vote(self::VOTER, 'up');
+        $positive = (float) $this->discussionRow()->hotness;
+        $this->assertGreaterThan(0, $positive);
+
+        // A net-negative discussion mirrors it: same magnitude, opposite sign.
+        $this->vote(self::VOTER, 'down');
+        $this->assertSame(-$positive, (float) $this->discussionRow()->hotness);
+
+        $this->vote(self::VOTER, null);
+        $this->assertSame(0.0, (float) $this->discussionRow()->hotness);
+    }
+
+    #[Test]
+    public function only_the_first_posts_votes_reach_the_discussion_tally()
+    {
+        // firstPostOnly is off, so the reply is votable — but a discussion's
+        // tally is defined as its first post's votes, not the sum of all posts.
+        $this->boot(['fof-gamification.firstPostOnly' => 0]);
+
+        $this->vote(self::VOTER, 'up', 2);
+
+        $this->assertSame([self::VOTER => 1], $this->voteRows(2));
+        $this->assertSame(1, $this->authorVotes(), 'the author is credited for the reply');
+        $this->assertSame(0, (int) $this->discussionRow()->votes, 'but the discussion tally is unmoved');
+    }
+
+    #[Test]
+    public function a_vote_on_a_reply_is_refused_while_first_post_only_is_on()
+    {
+        $this->boot();
+
+        $this->assertSame(403, $this->vote(self::VOTER, 'up', 2));
+        $this->assertSame([], $this->voteRows(2));
+        $this->assertSame(0, $this->authorVotes());
+    }
+
+    #[Test]
+    public function the_author_can_vote_on_their_own_post_by_default()
+    {
+        $this->boot();
+
+        $this->assertSame(200, $this->vote(self::AUTHOR, 'up'));
+        $this->assertSame(1, $this->authorVotes(), 'and it counts toward their own total');
+    }
+
+    #[Test]
+    public function disabling_self_votes_refuses_the_authors_vote_and_records_nothing()
+    {
+        $this->boot(['fof-gamification.allowSelfVotes' => 0]);
+
+        $this->assertSame(403, $this->vote(self::AUTHOR, 'up'));
+        $this->assertSame([], $this->voteRows());
+        $this->assertSame(0, $this->authorVotes());
+    }
+
+    #[Test]
+    public function a_user_without_the_vote_permission_is_refused()
+    {
+        $this->boot();
+
+        // User 1 is the admin, so use a member outside the voter group: revoke
+        // the group's permission instead.
+        $this->database()->table('group_permission')
+            ->where('permission', 'discussion.votePosts')->delete();
+
+        $this->assertSame(403, $this->vote(self::VOTER, 'up'));
+        $this->assertSame([], $this->voteRows());
+    }
+
+    #[Test]
+    public function a_guest_cannot_vote()
+    {
+        $this->boot();
+
+        $response = $this->send(
+            $this->request('PATCH', '/api/posts/1', [
+                'json' => ['data' => ['attributes' => ['vote' => 'up']]],
+            ])
+        );
+
+        // 400 rather than 401/403: the vote field is writable only when the
+        // actor can vote, so for a guest it is not a writable field at all and
+        // the request fails validation before any authorization check.
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame([], $this->voteRows());
+    }
+}

--- a/tests/integration/api/VoteWritePathTest.php
+++ b/tests/integration/api/VoteWritePathTest.php
@@ -298,16 +298,16 @@ class VoteWritePathTest extends EnhancedTestCase
     {
         $this->boot();
 
+        // Authenticated requests get the CSRF bypass for free via
+        // authenticatedAs; a guest request has to ask for it, or the response
+        // is a CSRF failure rather than the authorization outcome under test.
         $response = $this->send(
             $this->request('PATCH', '/api/posts/1', [
                 'json' => ['data' => ['attributes' => ['vote' => 'up']]],
-            ])
+            ])->withAttribute('bypassCsrfToken', true)
         );
 
-        // 400 rather than 401/403: the vote field is writable only when the
-        // actor can vote, so for a guest it is not a writable field at all and
-        // the request fails validation before any authorization check.
-        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame(401, $response->getStatusCode());
         $this->assertSame([], $this->voteRows());
     }
 }

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -8,6 +8,7 @@
     colors="true"
     processIsolation="true"
     stopOnFailure="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
 >
     <source>
         <include>

--- a/tests/phpunit.unit.xml
+++ b/tests/phpunit.unit.xml
@@ -8,6 +8,7 @@
     colors="true"
     processIsolation="false"
     stopOnFailure="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
 >
     <source>
         <include>


### PR DESCRIPTION
Removes every per-record query pattern this extension introduced on the discussion list, post stream and user list, behind a behavioural safety net written first.

## The problem

The discussion index and post stream each ran several N+1 queries originating entirely in this extension. Measured with flarum/testing's repeated-query detector over a ten-discussion fixture, and confirmed against a control run with the extension **disabled**, which is clean.

## Results so far

Queries per request, ten discussions:

| Endpoint | Actor | Before | After |
|---|---|---|---|
| `/api/discussions` | member | 26 | **16** |
| `/api/posts` | member | 50 | **22** |
| `/api/posts` | guest | 23 | **15** |
| `/api/users` | member | 20 | **16** |

No per-record query patterns remain on any endpoint this extension touches.

---

## Phase 1 — pin the behaviour first

The observable behaviour here is the product of `firstPostOnly`, `allowSelfVotes`, three independent permissions, and whether the actor is a guest, the post's author or someone else — resolved across serializer callbacks and a policy rather than in one place. The existing suite covered single records under default settings, so none of those combinations were protected. Optimising first would have meant changing policy and serialization paths with no way to tell whether the payload had moved.

So the first commit adds tests asserting **what the extension does today**:

- Guests on both endpoints, including which keys are **omitted** rather than false-valued (the frontend reads `canVote` to decide whether to show a control that prompts for login, so the shape matters).
- `firstPostOnly` on/off, against the first post and a reply.
- `allowSelfVotes` on/off, against the post's author and other members.
- Each permission granted independently, pinning the `canSeeVotes` ("See up/down vote count") vs `canSeeVoters` ("See who voted") split — holding one without the other is a legitimate configuration.
- **Tag-scoped permissions.** discuss.flarum.org grants the vote permissions only as `tag<id>.discussion.*`, with no global grant, so access there depends on the discussion's tags rather than the actor's groups alone. Nothing covered that path, and a policy or eager-loading change could easily start consulting the global permission instead.

These tests passed **unmodified** through every change below, which is what makes the optimisation provably behaviour-neutral.

phpunit configs now set `displayDetailsOnTestsThatTriggerWarnings`, so the detector's output is visible rather than a silent "OK, but there were issues".

## Phase 2 — the optimisations

**The discussion list re-fetched the rows it was serializing.** Tracing the repeated query showed the dominant cost was not the first-post lookup it appeared to be: `canVote` asks the post policy, which reads `$post->discussion`. The index eager loads `firstPost` but not *its* `discussion`, so every discussion in the list lazy-loaded the very row being serialized. Handing the post the discussion we already hold removes it entirely.

Alongside that, in `DiscussionResourceFields`:

- The `visible()` callback resolved the first post *before* checking whether the actor was a guest, so guests paid a per-discussion query for fields that are never sent to them. The actor check now comes first.
- Three fields each resolved the first post independently; it is now resolved once per discussion and memoised.

**The posts endpoint had the same problem one level down.** Every post serializes its discussion, and a discussion's vote fields resolve through its own first post — but only the discussion index eager loaded that, so a posts request fetched the first post and its votes one discussion at a time. The posts endpoint owns the query when discussions are serialized as included resources, so the nested loads belong there.

The vote constraint also ran for guests, matching on a null user id; it now uses a sentinel so the load stays batched without pretending a guest might have voted.

**A regression test** now runs each endpoint against enough records for a per-record pattern to be visible, so the detector fails the build if this returns. Verified to bite: three of its four cases fail against the previous code.

---

## Noted, not changed

`upVotesOnly` is enforced frontend-only — it is serialized to the forum and read in `useAlternatePostVoteLayout.tsx`, but no backend check consults it, so the API still accepts a downvote when it is enabled. Out of scope for performance work and deserving its own decision; deliberately left unpinned, since a test would enshrine it.

## The user list

`canHaveVotingNotifications` is resolved for every user in a listing and depends only on that user's groups, so users sharing a set of groups share an answer. The detector saw seven permission lookups across two distinct binding sets; the answer is now computed once per group set.

## The vote write path, pinned

Nothing in the suite cast a vote before this — every test read pre-seeded rows — so the entire write path was unprotected. One vote updates the vote row, the author's running total, the discussion's tally and hotness, and the author's ranks, then dispatches events driving notifications and auto-assigned groups. A wrong change there corrupts scores silently rather than raising an error.

Now covered: recording a vote and each tally it moves, repeat votes being idempotent, switching direction, clearing a vote, several voters accumulating, ranks granted on reaching a threshold and revoked when points fall back, hotness tracking the tally, replies counting toward the author but not the discussion, and the refusals — replies under `firstPostOnly`, self-votes when disabled, missing permission, and guests.

Two behaviours were found by observation rather than assumption, and are pinned as such: clearing a vote leaves a row with `value = 0` rather than deleting it, and the guest refusal is a 401 (the guest request needs the CSRF bypass that `authenticatedAs` grants automatically — without it the test was asserting a CSRF rejection instead of the authorization outcome).

These tests make the write path safe to optimise later, which matters because it is the extension's most expensive action: **40 queries and ~129ms for a single vote**, against 16 for the whole discussion index. `Vote::updateUserVotes()` re-aggregates the author's entire vote history on every vote — work that scales with everything the author has ever received rather than with the one vote just cast — ranks are re-synced each time, and the same user is reloaded five times per request. That is a separate change against a different risk profile (data correctness, not query counts), so it belongs in its own PR rather than bolted onto this one. The repeated user loads are recorded as a known allowance so the detector documents them rather than failing.

## Where I stopped, and why

`PostPolicy::canSeeVotes()` is reached about eight times per post — 79 invocations for ten posts — and it was the obvious next candidate. Measuring first showed it is **not worth memoising**: the queries behind it are already batched by the changes above, so what remains is settings reads, and those are served from memory. Three hundred and sixty of them cost 0ms of the request's ~34ms. A memo there would add cache-invalidation risk for no measurable gain.

That repetition is a real pattern, but the right place to address it is core: `Gate::allows()` caches policy *instances* and never *results*, so every extension that serializes policy-backed fields rediscovers this and hand-rolls its own memo. Raising that separately with the measurements from this work, rather than adding a fourth private cache here.


