### PR TITLE
[2.x] feat: confine gamification to chosen tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     ],
     "require": {
         "flarum/core": "^2.0.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "flarum/tags": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/extend.php
+++ b/extend.php
@@ -88,6 +88,7 @@ return [
         ->default('fof-gamification.rankAmt', 2)
         ->default('fof-gamification.firstPostOnly', true)
         ->default('fof-gamification.allowSelfVotes', true)
+        ->default(EnabledTags::SETTING, '')
         ->serializeToForum('fof-gamification.showVotesOnDiscussionPage', 'fof-gamification.showVotesOnDiscussionPage', 'boolval')
         ->serializeToForum('fof-gamification.useAlternateLayout', 'fof-gamification.useAlternateLayout', 'boolval')
         ->serializeToForum('fof-gamification.upVotesOnly', 'fof-gamification.upVotesOnly', 'boolval')

--- a/js/src/admin/components/SettingsPage.js
+++ b/js/src/admin/components/SettingsPage.js
@@ -7,6 +7,7 @@ import withAttr from 'flarum/common/utils/withAttr';
 import Stream from 'flarum/common/utils/Stream';
 import ItemList from 'flarum/common/utils/ItemList';
 import Form from 'flarum/common/components/Form';
+import FormGroup from 'flarum/common/components/FormGroup';
 import FormSection from 'flarum/admin/components/FormSection';
 import FormSectionGroup from 'flarum/admin/components/FormSectionGroup';
 import UploadImageButton from './UploadImageButton';
@@ -27,6 +28,7 @@ export default class SettingsPage extends ExtensionPage {
       'blockedUsers',
       'iconNameAlt',
       'autoAssignedGroups',
+      'enabled-tags',
     ];
 
     this.switches = [
@@ -345,6 +347,18 @@ export default class SettingsPage extends ExtensionPage {
 
   voteItems() {
     const items = new ItemList();
+
+    items.add(
+      'enabledTags',
+      <FormGroup
+        type="flarum-tags.select-tags"
+        label={app.translator.trans('fof-gamification.admin.page.votes.enabled_tags')}
+        help={app.translator.trans('fof-gamification.admin.page.votes.enabled_tags_help')}
+        stream={this.values['enabled-tags']}
+        options={{ requireParentTag: false }}
+      />,
+      100
+    );
 
     items.add(
       'icon',

--- a/js/src/forum/addVoteButtons.js
+++ b/js/src/forum/addVoteButtons.js
@@ -29,7 +29,10 @@ export default function () {
   extend(CommentPost.prototype, 'actionItems', function (items) {
     const post = this.attrs.post;
 
-    //if (!post.canVote()) return;
+    // Render nothing at all where voting does not apply — a disabled control
+    // still tells the reader that voting exists here. The alternate layout
+    // already does this; the two now behave the same way.
+    if (!post.canSeeVotes()) return;
 
     const hasDownvoted = post.hasDownvoted();
     const hasUpvoted = post.hasUpvoted();

--- a/migrations/2026_08_02_000000_seed_enabled_tags_setting.php
+++ b/migrations/2026_08_02_000000_seed_enabled_tags_setting.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use FoF\Gamification\EnabledTags;
+use Illuminate\Database\Schema\Builder;
+
+/**
+ * Seed the enabled-tags setting from the permissions a forum already has, so
+ * that gaining a per-tag switch does not change where voting works.
+ *
+ * See EnabledTags::seedFromPermissions() for why a forum-wide grant means
+ * "every tag" rather than the tags that happen to carry per-tag vote rows.
+ */
+return [
+    'up' => function (Builder $schema) {
+        $connection = $schema->getConnection();
+
+        if ($connection->table('settings')->where('key', EnabledTags::SETTING)->exists()) {
+            return;
+        }
+
+        // Migrations run regardless of which other extensions are installed,
+        // and this one reads the tags table. Without flarum/tags there is
+        // nothing to seed from — and nothing to gate, since a forum with no
+        // tags has no per-tag distinction to make.
+        if (! $schema->hasTable('tags')) {
+            return;
+        }
+
+        $permissions = $connection->table('group_permission')->pluck('permission')->all();
+        $tagIds = $connection->table('tags')->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $connection->table('settings')->insert([
+            'key'   => EnabledTags::SETTING,
+            'value' => json_encode(EnabledTags::seedFromPermissions($permissions, $tagIds)),
+        ]);
+    },
+    'down' => function (Builder $schema) {
+        $schema->getConnection()->table('settings')
+            ->where('key', EnabledTags::SETTING)
+            ->delete();
+    },
+];

--- a/migrations/2026_08_02_000000_seed_enabled_tags_setting.php
+++ b/migrations/2026_08_02_000000_seed_enabled_tags_setting.php
@@ -31,7 +31,7 @@ return [
         // and this one reads the tags table. Without flarum/tags there is
         // nothing to seed from — and nothing to gate, since a forum with no
         // tags has no per-tag distinction to make.
-        if (! $schema->hasTable('tags')) {
+        if (!$schema->hasTable('tags')) {
             return;
         }
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -59,6 +59,8 @@ fof-gamification:
       alt_votes:
         icon_name: Alt layout icon name
       votes:
+        enabled_tags: Tags with voting enabled
+        enabled_tags_help: Voting only appears in discussions carrying one of these tags. Leave empty to disable voting everywhere. This applies to everyone, including administrators — permissions still control who may vote within these tags.
         points_title: Points Placeholder
         points_placeholder: "Points: "
         color_holder: '#ffffff'

--- a/src/Access/PostPolicy.php
+++ b/src/Access/PostPolicy.php
@@ -15,11 +15,13 @@ use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\Access\AbstractPolicy;
 use Flarum\User\User;
+use FoF\Gamification\TagGate;
 
 class PostPolicy extends AbstractPolicy
 {
     public function __construct(
-        protected SettingsRepositoryInterface $settings
+        protected SettingsRepositoryInterface $settings,
+        protected TagGate $tags
     ) {
     }
 
@@ -35,6 +37,12 @@ class PostPolicy extends AbstractPolicy
 
     public function vote(User $actor, Post $post): string|bool|null
     {
+        // Availability first, and deliberately before any permission check:
+        // this gate applies to admins too, who bypass permissions entirely.
+        if (! $this->tags->allowsPost($post)) {
+            return $this->deny();
+        }
+
         if ($post->number !== 1 && $this->isFirstPostOnlyMode()) {
             return $this->deny();
         }
@@ -48,6 +56,12 @@ class PostPolicy extends AbstractPolicy
 
     public function canSeeVotes(User $actor, Post $post): string|bool|null
     {
+        // Availability first, and deliberately before any permission check:
+        // this gate applies to admins too, who bypass permissions entirely.
+        if (! $this->tags->allowsPost($post)) {
+            return $this->deny();
+        }
+
         if ($post->number !== 1 && $this->isFirstPostOnlyMode()) {
             return $this->deny();
         }
@@ -57,6 +71,12 @@ class PostPolicy extends AbstractPolicy
 
     public function canSeeVoters(User $actor, Post $post): string|bool|null
     {
+        // Availability first, and deliberately before any permission check:
+        // this gate applies to admins too, who bypass permissions entirely.
+        if (! $this->tags->allowsPost($post)) {
+            return $this->deny();
+        }
+
         if ($post->number !== 1 && $this->isFirstPostOnlyMode()) {
             return $this->deny();
         }

--- a/src/Access/PostPolicy.php
+++ b/src/Access/PostPolicy.php
@@ -39,7 +39,7 @@ class PostPolicy extends AbstractPolicy
     {
         // Availability first, and deliberately before any permission check:
         // this gate applies to admins too, who bypass permissions entirely.
-        if (! $this->tags->allowsPost($post)) {
+        if (!$this->tags->allowsPost($post)) {
             return $this->deny();
         }
 
@@ -58,7 +58,7 @@ class PostPolicy extends AbstractPolicy
     {
         // Availability first, and deliberately before any permission check:
         // this gate applies to admins too, who bypass permissions entirely.
-        if (! $this->tags->allowsPost($post)) {
+        if (!$this->tags->allowsPost($post)) {
             return $this->deny();
         }
 
@@ -73,7 +73,7 @@ class PostPolicy extends AbstractPolicy
     {
         // Availability first, and deliberately before any permission check:
         // this gate applies to admins too, who bypass permissions entirely.
-        if (! $this->tags->allowsPost($post)) {
+        if (!$this->tags->allowsPost($post)) {
             return $this->deny();
         }
 

--- a/src/Api/DiscussionResourceFields.php
+++ b/src/Api/DiscussionResourceFields.php
@@ -14,6 +14,7 @@ namespace FoF\Gamification\Api;
 use Flarum\Api\Context;
 use Flarum\Api\Schema;
 use Flarum\Discussion\Discussion;
+use FoF\Gamification\TagGate;
 use Flarum\Post\Post;
 
 class DiscussionResourceFields
@@ -31,9 +32,23 @@ class DiscussionResourceFields
      */
     private \WeakMap $firstPosts;
 
-    public function __construct()
-    {
+    public function __construct(
+        protected TagGate $tags
+    ) {
         $this->firstPosts = new \WeakMap();
+    }
+
+    /**
+     * Whether the actor may see this discussion's vote tally.
+     *
+     * These two fields ask the Discussion ability directly rather than going
+     * through the post policy, so they would otherwise bypass the tag gate and
+     * expose a tally on a tag where gamification is switched off.
+     */
+    private function seesVotes(Discussion $discussion, Context $context): bool
+    {
+        return $this->tags->allows($discussion)
+            && $context->getActor()->can('canSeeVotes', $discussion);
     }
 
     /**
@@ -87,10 +102,10 @@ class DiscussionResourceFields
                     return $post?->actualvotes->firstWhere('user_id', $context->getActor()->id)?->isDownvote() ?? false;
                 }),
             Schema\Number::make('votes')
-                ->visible(fn (Discussion $discussion, Context $context) => $context->getActor()->can('canSeeVotes', $discussion))
+                ->visible(fn (Discussion $discussion, Context $context) => $this->seesVotes($discussion, $context))
                 ->get(fn (Discussion $discussion) => $discussion->votes),
             Schema\Boolean::make('seeVotes')
-                ->get(fn (Discussion $discussion, Context $context) => $context->getActor()->can('canSeeVotes', $discussion)),
+                ->get(fn (Discussion $discussion, Context $context) => $this->seesVotes($discussion, $context)),
             Schema\Boolean::make('canVote')
                 ->get(function (Discussion $discussion, Context $context) {
                     $post = $this->firstPost($discussion);

--- a/src/Api/DiscussionResourceFields.php
+++ b/src/Api/DiscussionResourceFields.php
@@ -14,8 +14,8 @@ namespace FoF\Gamification\Api;
 use Flarum\Api\Context;
 use Flarum\Api\Schema;
 use Flarum\Discussion\Discussion;
-use FoF\Gamification\TagGate;
 use Flarum\Post\Post;
+use FoF\Gamification\TagGate;
 
 class DiscussionResourceFields
 {

--- a/src/EnabledTags.php
+++ b/src/EnabledTags.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Gamification;
+
+class EnabledTags
+{
+    public const SETTING = 'fof-gamification.enabled-tags';
+
+    /**
+     * The vote abilities whose presence means gamification is in use.
+     */
+    private const VOTE_ABILITIES = ['votePosts', 'canSeeVotes', 'canSeeVoters'];
+
+    /**
+     * Work out which tags gamification should be enabled on, from the
+     * permissions a forum already has, so that upgrading changes nothing about
+     * where voting works.
+     *
+     * A forum-wide `discussion.votePosts` (or the see-votes equivalent) means
+     * voting is available everywhere, and every tag is enabled. Per-tag rows
+     * are deliberately ignored in that case: a restricted tag re-grants the
+     * abilities its members need — reply, likePosts, viewForum and often the
+     * vote ones too — so they describe access control for that tag rather than
+     * where gamification belongs. Treating them as intent would disable voting
+     * on every other tag.
+     *
+     * Without a global grant, the per-tag rows are the only signal there is,
+     * and they do carry the intent: voting exists exactly where a tag grants
+     * it.
+     *
+     * @param string[] $permissions all permission names granted on the forum
+     * @param int[]    $tagIds      the ids of the tags that currently exist
+     *
+     * @return string[] tag ids, as the strings the setting stores
+     */
+    public static function seedFromPermissions(array $permissions, array $tagIds): array
+    {
+        foreach (self::VOTE_ABILITIES as $ability) {
+            if (in_array("discussion.$ability", $permissions, true)) {
+                return array_map('strval', array_values($tagIds));
+            }
+        }
+
+        $granted = [];
+
+        foreach ($permissions as $permission) {
+            if (preg_match('/^tag(\d+)\.discussion\.([A-Za-z]+)$/', $permission, $matches)
+                && in_array($matches[2], self::VOTE_ABILITIES, true)) {
+                $granted[(int) $matches[1]] = true;
+            }
+        }
+
+        // Permission rows outlive the tags they name, so only keep ids that
+        // still resolve to a tag.
+        return array_map('strval', array_values(array_filter(
+            $tagIds,
+            fn (int $id) => isset($granted[$id])
+        )));
+    }
+}

--- a/src/TagGate.php
+++ b/src/TagGate.php
@@ -60,7 +60,7 @@ class TagGate
 
     public function allows(Discussion $discussion): bool
     {
-        if (! isset($this->answers[$discussion])) {
+        if (!isset($this->answers[$discussion])) {
             $this->answers[$discussion] = $this->resolve($discussion);
         }
 
@@ -77,7 +77,7 @@ class TagGate
         // or has no tags — keeps gamification everywhere rather than silently
         // losing it. An empty list, by contrast, is a deliberate choice: the
         // migration always writes a value.
-        if (! $this->configured) {
+        if (!$this->configured) {
             return true;
         }
 
@@ -123,7 +123,7 @@ class TagGate
 
         $decoded = json_decode($raw, true);
 
-        if (! is_array($decoded)) {
+        if (!is_array($decoded)) {
             $this->configured = false;
 
             return $this->enabled = [];

--- a/src/TagGate.php
+++ b/src/TagGate.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Gamification;
+
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Settings\SettingsRepositoryInterface;
+
+/**
+ * Decides whether gamification applies to a discussion at all.
+ *
+ * This is availability, not access: it answers "is voting a thing here?"
+ * rather than "may this person vote?". Keeping it out of the permission system
+ * is the point — admins bypass permission checks, so an admin previously saw
+ * vote controls on every tag no matter how the forum was configured. A gate
+ * that is not a permission applies to them too.
+ *
+ * Permissions still do their own job on top of this.
+ */
+class TagGate
+{
+    /**
+     * Enabled tag ids, parsed once per request. Null until first read.
+     *
+     * @var int[]|null
+     */
+    private ?array $enabled = null;
+
+    private bool $configured = false;
+
+    /**
+     * Per-discussion answers, keyed by the discussion instance, so the several
+     * serialized fields that each ask this question resolve it once.
+     *
+     * @var \WeakMap<Discussion, mixed>
+     */
+    private \WeakMap $answers;
+
+    public function __construct(
+        protected SettingsRepositoryInterface $settings
+    ) {
+        $this->answers = new \WeakMap();
+    }
+
+    public function allowsPost(Post $post): bool
+    {
+        $discussion = $post->discussion;
+
+        return $discussion === null || $this->allows($discussion);
+    }
+
+    public function allows(Discussion $discussion): bool
+    {
+        if (! isset($this->answers[$discussion])) {
+            $this->answers[$discussion] = $this->resolve($discussion);
+        }
+
+        return $this->answers[$discussion];
+    }
+
+    private function resolve(Discussion $discussion): bool
+    {
+        // Resolve first: reading the setting is what establishes whether the
+        // forum is configured at all.
+        $enabled = $this->enabledTagIds();
+
+        // An unconfigured forum — one that has not run the seeding migration,
+        // or has no tags — keeps gamification everywhere rather than silently
+        // losing it. An empty list, by contrast, is a deliberate choice: the
+        // migration always writes a value.
+        if (! $this->configured) {
+            return true;
+        }
+
+        if ($enabled === []) {
+            return false;
+        }
+
+        // `tags` reaches Discussion through an extender rather than the model,
+        // so it is neither a declared property nor a callable relation method,
+        // and it reads as null on a discussion that has none.
+        /** @phpstan-ignore-next-line */
+        $tags = $discussion->tags ?? [];
+
+        // An untagged discussion carries no enabled tag, so gamification does
+        // not apply. With flarum/tags a hard dependency every discussion is
+        // expected to be tagged, so this is not a state worth a setting of its
+        // own.
+        foreach ($tags as $tag) {
+            if (in_array((int) $tag->id, $enabled, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function enabledTagIds(): array
+    {
+        if ($this->enabled !== null) {
+            return $this->enabled;
+        }
+
+        $raw = $this->settings->get(EnabledTags::SETTING);
+
+        if ($raw === null || $raw === '') {
+            $this->configured = false;
+
+            return $this->enabled = [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        if (! is_array($decoded)) {
+            $this->configured = false;
+
+            return $this->enabled = [];
+        }
+
+        $this->configured = true;
+
+        return $this->enabled = array_map('intval', $decoded);
+    }
+}

--- a/tests/integration/EnabledTagsMigrationTest.php
+++ b/tests/integration/EnabledTagsMigrationTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Gamification\Tests\integration;
+
+use FoF\Gamification\EnabledTags;
+use FoF\Gamification\Tests\EnhancedTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The upgrade must not change where voting works.
+ *
+ * Voting is currently expressed through permissions, and forums express it in
+ * two quite different shapes. Both are real, and the seed is written against
+ * both:
+ *
+ *  - **Global grant.** `discussion.votePosts` is granted forum-wide, so voting
+ *    is available on every tag. Restricted tags then subtract it, and re-grant
+ *    it through `tag<id>.discussion.votePosts` where members should keep it.
+ *    Those per-tag rows are part of a general access-control setup for the
+ *    restricted tag — they sit alongside `reply`, `likePosts`, `viewForum` and
+ *    the rest — so they say nothing about where gamification is *wanted*.
+ *    Reading them as intent would wrongly narrow the forum to those tags.
+ *
+ *  - **No global grant.** Voting exists only where a tag explicitly grants it.
+ *    Here the per-tag rows *are* the intent, and are the only signal available.
+ *
+ * So the global grant decides which reading applies. Anything else silently
+ * turns voting off somewhere it currently works.
+ */
+class EnabledTagsMigrationTest extends EnhancedTestCase
+{
+    /**
+     * @param string[] $permissions
+     * @param int[]    $tagIds
+     *
+     * @return string[]
+     */
+    private function seed(array $permissions, array $tagIds): array
+    {
+        return EnabledTags::seedFromPermissions($permissions, $tagIds);
+    }
+
+    #[Test]
+    public function a_forum_with_a_global_grant_enables_every_tag()
+    {
+        // dev.flarum.one: Member holds discussion.votePosts forum-wide, so
+        // voting works on all 33 tags today and must continue to.
+        $seeded = $this->seed(
+            ['discussion.votePosts', 'discussion.canSeeVotes', 'tag35.discussion.votePosts'],
+            [34, 35, 13, 26]
+        );
+
+        $this->assertSame(['34', '35', '13', '26'], $seeded);
+    }
+
+    #[Test]
+    public function per_tag_grants_are_ignored_when_a_global_grant_exists()
+    {
+        // The restricted tag's own votePosts row is part of re-granting normal
+        // abilities inside that tag, not a statement that gamification belongs
+        // only there. Narrowing to it would disable voting on every other tag.
+        $seeded = $this->seed(
+            ['discussion.votePosts', 'tag35.discussion.votePosts'],
+            [34, 35]
+        );
+
+        $this->assertContains('34', $seeded, 'the unrestricted tag keeps voting');
+    }
+
+    #[Test]
+    public function a_forum_without_a_global_grant_enables_only_the_granted_tags()
+    {
+        // discuss.flarum.org: no global grant at all, and exactly one tag
+        // carries the vote permissions. Voting is confined there today.
+        $seeded = $this->seed(
+            ['tag97.discussion.votePosts', 'tag97.discussion.canSeeVotes', 'tag97.discussion.canSeeVoters'],
+            [97, 12, 45]
+        );
+
+        $this->assertSame(['97'], $seeded);
+    }
+
+    #[Test]
+    public function the_see_votes_permission_alone_enables_a_tag()
+    {
+        // A tag that only exposes the tally still shows gamification, so it
+        // must stay enabled or the counts vanish on upgrade.
+        $seeded = $this->seed(['tag5.discussion.canSeeVotes'], [5, 6]);
+
+        $this->assertSame(['5'], $seeded);
+    }
+
+    #[Test]
+    public function unrelated_tag_permissions_do_not_enable_a_tag()
+    {
+        // A restricted tag re-grants many abilities; only the vote ones count.
+        $seeded = $this->seed(
+            ['tag26.discussion.reply', 'tag26.discussion.likePosts', 'tag26.viewForum'],
+            [26, 27]
+        );
+
+        $this->assertSame([], $seeded);
+    }
+
+    #[Test]
+    public function a_forum_with_no_vote_permissions_at_all_enables_nothing()
+    {
+        $this->assertSame([], $this->seed(['discussion.reply'], [1, 2]));
+    }
+
+    #[Test]
+    public function a_grant_for_a_deleted_tag_is_dropped()
+    {
+        // Permission rows outlive the tags they name; seeding a stale id would
+        // put an unresolvable tag in the setting.
+        $seeded = $this->seed(['tag999.discussion.votePosts'], [1, 2]);
+
+        $this->assertSame([], $seeded);
+    }
+
+    #[Test]
+    public function the_two_real_forum_configurations_are_preserved_exactly()
+    {
+        // Taken verbatim from the two forums this was designed against, so the
+        // shapes here are real rather than imagined.
+
+        // dev: Member holds discussion.votePosts forum-wide; tag 35 is a
+        // restricted tag whose members have been re-granted the normal set of
+        // abilities, voting among them.
+        $devPermissions = [
+            'discussion.canSeeVotes', 'discussion.votePosts', 'tag26.discussion.polls.vote',
+            'tag35.discussion.canSeeReactions', 'tag35.discussion.canSeeVoters', 'tag35.discussion.canSeeVotes',
+            'tag35.discussion.flagPosts', 'tag35.discussion.likePosts', 'tag35.discussion.reactPosts',
+            'tag35.discussion.reply', 'tag35.discussion.votePosts', 'tag35.startDiscussion', 'tag35.viewForum',
+        ];
+        $devTags = [1, 6, 13, 26, 34, 35];
+
+        $this->assertSame(
+            ['1', '6', '13', '26', '34', '35'],
+            $this->seed($devPermissions, $devTags),
+            'voting is forum-wide there today and must stay so'
+        );
+
+        // discuss: no global grant; exactly one tag carries the vote
+        // permissions, and voting is confined to it.
+        $this->assertSame(
+            ['97'],
+            $this->seed(
+                ['tag97.discussion.canSeeVoters', 'tag97.discussion.canSeeVotes', 'tag97.discussion.votePosts'],
+                [12, 45, 97]
+            ),
+            'voting is confined to one tag there today and must stay so'
+        );
+    }
+
+    #[Test]
+    public function the_seed_is_json_encodable_as_strings()
+    {
+        // The setting is consumed by the tag selector, which round-trips a JSON
+        // array of string ids.
+        $seeded = $this->seed(['discussion.votePosts'], [7, 8]);
+
+        $this->assertSame('["7","8"]', json_encode($seeded));
+    }
+}

--- a/tests/integration/TagGatingTest.php
+++ b/tests/integration/TagGatingTest.php
@@ -1,0 +1,250 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Gamification\Tests\integration;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Group\Group;
+use Flarum\Post\Post;
+use Flarum\Tags\Tag;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\User\User;
+use FoF\Gamification\EnabledTags;
+use FoF\Gamification\Tests\EnhancedTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Gamification is confined to the tags an admin has enabled.
+ *
+ * This is a feature-availability gate, deliberately *not* a permission: the
+ * point of it is that it applies to everyone. Permissions cannot express this
+ * on their own — an unrestricted tag has no per-tag permission dimension at
+ * all, and admins bypass permission checks entirely, so an admin saw vote
+ * controls on every tag on the forum no matter how it was configured.
+ *
+ * The two layers stay independent. This decides *where* gamification exists;
+ * permissions still decide *who* may use it there.
+ */
+class TagGatingTest extends EnhancedTestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    private const ENABLED_TAG = 10;
+    private const OTHER_TAG = 11;
+    private const MEMBER = 3;
+    private const ADMIN = 1;
+
+    /**
+     * @param string[]|null $enabledTags null leaves the setting unset
+     */
+    private function boot(?array $enabledTags = ['10']): void
+    {
+        if ($enabledTags !== null) {
+            $this->setting(EnabledTags::SETTING, json_encode($enabledTags));
+        }
+
+        $this->extension('flarum-tags', 'fof-gamification');
+
+        $now = Carbon::now()->toDateTimeString();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(), // id 2, the author
+                ['id' => 3, 'username' => 'member', 'email' => 'member@machine.local', 'is_email_confirmed' => 1],
+            ],
+            Group::class => [
+                ['id' => 100, 'name_singular' => 'Voter', 'name_plural' => 'Voters'],
+            ],
+            'group_user' => [
+                ['user_id' => 2, 'group_id' => 100],
+                ['user_id' => 3, 'group_id' => 100],
+            ],
+            'group_permission' => [
+                ['group_id' => 100, 'permission' => 'discussion.votePosts'],
+                ['group_id' => 100, 'permission' => 'discussion.canSeeVotes'],
+                ['group_id' => 100, 'permission' => 'discussion.canSeeVoters'],
+            ],
+            Tag::class => [
+                ['id' => self::ENABLED_TAG, 'name' => 'Enabled', 'slug' => 'enabled', 'position' => 0, 'is_restricted' => 0],
+                ['id' => self::OTHER_TAG, 'name' => 'Other', 'slug' => 'other', 'position' => 1, 'is_restricted' => 0],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'In the enabled tag', 'created_at' => $now, 'last_posted_at' => $now, 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'is_private' => 0],
+                ['id' => 2, 'title' => 'In another tag', 'created_at' => $now, 'last_posted_at' => $now, 'user_id' => 2, 'first_post_id' => 2, 'comment_count' => 1, 'is_private' => 0],
+                ['id' => 3, 'title' => 'Untagged', 'created_at' => $now, 'last_posted_at' => $now, 'user_id' => 2, 'first_post_id' => 3, 'comment_count' => 1, 'is_private' => 0],
+                ['id' => 4, 'title' => 'Both tags', 'created_at' => $now, 'last_posted_at' => $now, 'user_id' => 2, 'first_post_id' => 4, 'comment_count' => 1, 'is_private' => 0],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => self::ENABLED_TAG],
+                ['discussion_id' => 2, 'tag_id' => self::OTHER_TAG],
+                ['discussion_id' => 4, 'tag_id' => self::ENABLED_TAG],
+                ['discussion_id' => 4, 'tag_id' => self::OTHER_TAG],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'created_at' => $now, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>a</p></t>'],
+                ['id' => 2, 'discussion_id' => 2, 'number' => 1, 'created_at' => $now, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>b</p></t>'],
+                ['id' => 3, 'discussion_id' => 3, 'number' => 1, 'created_at' => $now, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>c</p></t>'],
+                ['id' => 4, 'discussion_id' => 4, 'number' => 1, 'created_at' => $now, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>d</p></t>'],
+            ],
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    private function postAttributes(int $postId, int $actor): array
+    {
+        $response = $this->send($this->request('GET', "/api/posts/$postId", ['authenticatedAs' => $actor]));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        return json_decode($response->getBody()->getContents(), true)['data']['attributes'];
+    }
+
+    /** @return array<string, mixed> */
+    private function discussionAttributes(int $discussionId, int $actor): array
+    {
+        $response = $this->send($this->request('GET', "/api/discussions/$discussionId", ['authenticatedAs' => $actor]));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        return json_decode($response->getBody()->getContents(), true)['data']['attributes'];
+    }
+
+    private function vote(int $postId, int $actor): int
+    {
+        return $this->send(
+            $this->request('PATCH', "/api/posts/$postId", [
+                'authenticatedAs' => $actor,
+                'json'            => ['data' => ['attributes' => ['vote' => 'up']]],
+            ])
+        )->getStatusCode();
+    }
+
+    #[Test]
+    public function a_member_can_vote_in_an_enabled_tag()
+    {
+        $this->boot();
+
+        $this->assertTrue($this->postAttributes(1, self::MEMBER)['canVote']);
+        $this->assertSame(200, $this->vote(1, self::MEMBER));
+    }
+
+    #[Test]
+    public function a_member_cannot_vote_outside_the_enabled_tags()
+    {
+        $this->boot();
+
+        $this->assertFalse($this->postAttributes(2, self::MEMBER)['canVote']);
+        $this->assertSame(403, $this->vote(2, self::MEMBER));
+    }
+
+    #[Test]
+    public function an_admin_is_gated_by_the_enabled_tags_too()
+    {
+        // The whole point: admins bypass permission checks, so before this an
+        // admin saw vote controls on every tag regardless of configuration.
+        // This gate is not a permission, so it applies to them as well.
+        $this->boot();
+
+        $this->assertTrue($this->postAttributes(1, self::ADMIN)['canVote'], 'still available where enabled');
+        $this->assertFalse($this->postAttributes(2, self::ADMIN)['canVote'], 'and gone where it is not');
+        $this->assertSame(403, $this->vote(2, self::ADMIN));
+    }
+
+    #[Test]
+    public function the_vote_count_is_hidden_outside_the_enabled_tags()
+    {
+        $this->boot();
+
+        $this->assertTrue($this->postAttributes(1, self::MEMBER)['canSeeVotes']);
+        $this->assertFalse($this->postAttributes(2, self::MEMBER)['canSeeVotes']);
+    }
+
+    #[Test]
+    public function one_enabled_tag_is_enough_when_a_discussion_has_several()
+    {
+        // Any enabled tag enables the discussion, which matches how admins
+        // describe it — "this is a Q&A tag" — rather than requiring every tag
+        // on the discussion to be enabled.
+        $this->boot();
+
+        $this->assertTrue($this->postAttributes(4, self::MEMBER)['canVote']);
+    }
+
+    #[Test]
+    public function untagged_discussions_are_not_gamified_when_tags_are_enabled()
+    {
+        // An untagged discussion carries no enabled tag, so it is outside the
+        // configured area.
+        $this->boot();
+
+        $this->assertFalse($this->postAttributes(3, self::MEMBER)['canVote']);
+    }
+
+    #[Test]
+    public function the_discussion_tally_is_hidden_outside_the_enabled_tags()
+    {
+        // seeVotes and votes ask the Discussion ability directly rather than
+        // going through the post policy, so they need gating of their own. A
+        // member holding canSeeVotes forum-wide would otherwise still be shown
+        // a tally on a tag where gamification is switched off — the guest case
+        // hides this, because a guest fails the permission check anyway.
+        $this->boot();
+
+        $enabled = $this->discussionAttributes(1, self::MEMBER);
+        $this->assertTrue($enabled['seeVotes']);
+        $this->assertArrayHasKey('votes', $enabled);
+
+        $gated = $this->discussionAttributes(2, self::MEMBER);
+        $this->assertFalse($gated['seeVotes'], 'no tally outside the enabled tags');
+        $this->assertArrayNotHasKey('votes', $gated);
+    }
+
+    #[Test]
+    public function an_empty_setting_disables_gamification_everywhere()
+    {
+        // The migration always seeds a value, so an empty list is a deliberate
+        // choice rather than an unconfigured forum.
+        $this->boot([]);
+
+        $this->assertFalse($this->postAttributes(1, self::MEMBER)['canVote']);
+        $this->assertFalse($this->postAttributes(3, self::MEMBER)['canVote']);
+    }
+
+    #[Test]
+    public function an_unset_setting_leaves_gamification_available_everywhere()
+    {
+        // A forum that has not run the migration — or has no tags at all —
+        // must not silently lose voting.
+        $this->boot(null);
+
+        // The seeding migration runs during setup, so clear what it wrote to
+        // model a forum that has not been configured.
+        $this->app()->getContainer()->make(\Flarum\Settings\SettingsRepositoryInterface::class)
+            ->delete(EnabledTags::SETTING);
+
+        $this->assertTrue($this->postAttributes(1, self::MEMBER)['canVote']);
+        $this->assertTrue($this->postAttributes(2, self::MEMBER)['canVote']);
+        $this->assertTrue($this->postAttributes(3, self::MEMBER)['canVote'], 'including untagged discussions');
+    }
+
+    #[Test]
+    public function permissions_still_apply_within_an_enabled_tag()
+    {
+        // The gate decides where gamification exists; permissions still decide
+        // who may use it. Revoking the permission must still refuse the vote
+        // even though the tag is enabled.
+        $this->boot();
+
+        $this->database()->table('group_permission')
+            ->where('permission', 'discussion.votePosts')->delete();
+
+        $this->assertSame(403, $this->vote(1, self::MEMBER));
+    }
+}

--- a/tests/integration/api/VoteVisibilityCharacterisationTest.php
+++ b/tests/integration/api/VoteVisibilityCharacterisationTest.php
@@ -15,6 +15,7 @@ use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Post\Post;
+use Flarum\Tags\Tag;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\User\User;
 use FoF\Gamification\Tests\EnhancedTestCase;
@@ -62,7 +63,7 @@ class VoteVisibilityCharacterisationTest extends EnhancedTestCase
             $this->setting($key, $value);
         }
 
-        $this->extension('fof-gamification');
+        $this->extension('flarum-tags', 'fof-gamification');
 
         $now = Carbon::now()->toDateTimeString();
 
@@ -82,6 +83,12 @@ class VoteVisibilityCharacterisationTest extends EnhancedTestCase
                 fn (string $permission) => ['group_id' => self::VOTER_GROUP, 'permission' => $permission],
                 $permissions ?? ['discussion.canSeeVotes', 'discussion.canSeeVoters', 'discussion.votePosts']
             ),
+            Tag::class => [
+                ['id' => 1, 'name' => 'Gamified', 'slug' => 'gamified', 'position' => 0, 'is_restricted' => 0],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 1],
+            ],
             Discussion::class => [
                 ['id' => 1, 'title' => 'D', 'created_at' => $now, 'last_posted_at' => $now, 'user_id' => self::AUTHOR, 'first_post_id' => 1, 'comment_count' => 2, 'is_private' => 0, 'votes' => 1],
             ],

--- a/tests/integration/api/VoteWritePathTest.php
+++ b/tests/integration/api/VoteWritePathTest.php
@@ -15,6 +15,7 @@ use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Post\Post;
+use Flarum\Tags\Tag;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\User\User;
 use FoF\Gamification\Tests\EnhancedTestCase;
@@ -51,7 +52,7 @@ class VoteWritePathTest extends EnhancedTestCase
             $this->setting($key, $value);
         }
 
-        $this->extension('fof-gamification');
+        $this->extension('flarum-tags', 'fof-gamification');
 
         $now = Carbon::now()->toDateTimeString();
 
@@ -73,12 +74,22 @@ class VoteWritePathTest extends EnhancedTestCase
                 ['group_id' => self::VOTER_GROUP, 'permission' => 'discussion.votePosts'],
                 ['group_id' => self::VOTER_GROUP, 'permission' => 'discussion.canSeeVotes'],
             ],
+            Tag::class => [
+                ['id' => 1, 'name' => 'Gamified', 'slug' => 'gamified', 'position' => 0, 'is_restricted' => 0],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 1],
+            ],
             Discussion::class => [
                 ['id' => 1, 'title' => 'D', 'created_at' => $now, 'last_posted_at' => $now, 'user_id' => self::AUTHOR, 'first_post_id' => 1, 'comment_count' => 2, 'is_private' => 0],
+                // Deliberately left untagged, to prove gamification does not
+                // reach a discussion outside the enabled tags.
+                ['id' => 2, 'title' => 'Untagged', 'created_at' => $now, 'last_posted_at' => $now, 'user_id' => self::AUTHOR, 'first_post_id' => 3, 'comment_count' => 1, 'is_private' => 0],
             ],
             Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'created_at' => $now, 'user_id' => self::AUTHOR, 'type' => 'comment', 'content' => '<t><p>first</p></t>'],
                 ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'created_at' => $now, 'user_id' => self::AUTHOR, 'type' => 'comment', 'content' => '<t><p>reply</p></t>'],
+                ['id' => 3, 'discussion_id' => 2, 'number' => 1, 'created_at' => $now, 'user_id' => self::AUTHOR, 'type' => 'comment', 'content' => '<t><p>untagged</p></t>'],
             ],
             'ranks' => [
                 ['id' => 1, 'points' => 1, 'name' => 'Rookie', 'color' => '#ffffff'],
@@ -291,6 +302,18 @@ class VoteWritePathTest extends EnhancedTestCase
 
         $this->assertSame(403, $this->vote(self::VOTER, 'up'));
         $this->assertSame([], $this->voteRows());
+    }
+
+    #[Test]
+    public function a_vote_on_an_untagged_discussion_is_refused_and_records_nothing()
+    {
+        // The tag gate applies to the write path too, not just to what is
+        // serialized: a refused vote must leave no row and move no tally.
+        $this->boot();
+
+        $this->assertSame(403, $this->vote(self::VOTER, 'up', 3));
+        $this->assertSame([], $this->voteRows(3));
+        $this->assertSame(0, $this->authorVotes());
     }
 
     #[Test]


### PR DESCRIPTION
Gamification can now be limited to specific tags, chosen in the admin page. Adds a hard dependency on flarum/tags.

### Why

Voting is expressed entirely through permissions today, and permissions cannot say "only in these tags":

- **An unrestricted tag has no per-tag permission dimension.** `tag<id>.discussion.votePosts` is only consulted for tags where `is_restricted` is set, so on a public tag the row is ignored entirely. Confining voting to one public tag means restricting every other tag, which changes visibility semantics across the whole forum.
- **Administrators bypass permission checks.** However a forum is configured, an admin sees vote controls on every tag — which is what prompted this.

So the tags gamification applies to become an explicit setting. Permissions keep doing access control; the setting decides where the feature exists at all. Both have to pass, and because the gate is not a permission, it applies to administrators too.

### Upgrading changes nothing

The setting is seeded from the permissions a forum already has. Two shapes exist in the wild and the seed is written against both:

| Forum | Today | Seeds |
|---|---|---|
| Forum-wide `discussion.votePosts` | voting on every tag | every tag |
| No forum-wide grant, one tag granted | voting in that tag only | that tag |

Per-tag rows are deliberately ignored when a forum-wide grant exists. A restricted tag re-grants the abilities its members need — `reply`, `likePosts`, `viewForum`, and often the vote ones alongside them — so those rows describe access control for that tag, not where gamification belongs. Reading them as intent would have switched voting off everywhere else.

Verified against two live forums: one with a forum-wide grant seeds all of its tags, one that confines voting to a single tag seeds exactly that tag. Both are no-ops.

**Deploying needs a cache clear.** The migration writes straight to the settings table, so the cached payload keeps serving the previous state until it is cleared.

### What is gated

The post policy is consulted before any permission check, covering the six serialized post fields that resolve through it. The discussion's own `votes` and `seeVotes` ask the Discussion ability directly rather than going through that policy, so they are gated separately — without that, a member holding `canSeeVotes` forum-wide was still shown a tally on a tag where gamification is switched off.

Points and ranks stay global. They are properties of a user rather than of a discussion, and gating them would make the numbers move whenever the tag selection changed.

An untagged discussion carries no enabled tag and so is not gamified. A forum whose setting is missing keeps gamification everywhere, so one that has not run the migration does not silently lose voting.

The default post layout also stops rendering the vote widget where voting does not apply — it was disabling the buttons, which still tells the reader voting exists there. The alternate layout already returned early.

### Tests

59 tests, 180 assertions, PHPStan clean.

The seeding rule is covered against both real forum shapes, including the stale-tag and unrelated-permission cases. The gate is covered for enabled and non-enabled tags, multi-tag discussions, untagged discussions, an empty setting, an unset setting, that permissions still apply within an enabled tag, and — the point of the change — that an administrator is gated too.

The existing characterisation suites gain a tag on their fixtures, since an untagged discussion is no longer a realistic case, and keep an untagged one to prove a vote there is refused and records nothing.

Verified on a live install: only the two enabled tags show the UI, including as an administrator, and the API exposes no vote data elsewhere.