### PR TITLE
[2.x] fix: keep vote controls off deleted posts

### DIFF
--- a/js/src/forum/addVoteButtons.js
+++ b/js/src/forum/addVoteButtons.js
@@ -34,6 +34,11 @@ export default function () {
     // already does this; the two now behave the same way.
     if (!post.canSeeVotes()) return;
 
+    // A deleted post keeps no vote controls. The alternate layout bails out on
+    // hidden posts before it can swap this widget for its own, so adding it
+    // here at all left the buttons on show behind the deleted-post overlay.
+    if (post.isHidden()) return;
+
     const hasDownvoted = post.hasDownvoted();
     const hasUpvoted = post.hasUpvoted();
 


### PR DESCRIPTION
Closes #80, together with #160.

### The report

Two symptoms in one issue, both showing a vote widget where there should be none:

1. **An upvote icon on a tag gamification is not enabled for** — the screenshot in the issue shows it disabled rather than absent.
2. **The same widget on a soft-deleted post**, sitting behind the deleted-post overlay.

### The first half went with the tag gating

#160 made gamification confinable to chosen tags and, as part of that, stopped the default layout rendering a *disabled* widget where voting does not apply — a greyed-out control still tells the reader voting exists there. On a non-enabled tag nothing is rendered now, so that symptom is gone.

### This is the second half

The cause is an interaction between the two layouts rather than a missing check. `addVoteButtons` **adds** the `votes` item; `useAlternatePostVoteLayout` **removes** it and substitutes its own rendering. But the alternate layout returns early on a hidden post:

```js
if (this.attrs.post.isHidden()) return;

items.remove('votes');
```

so on a deleted post it bails out *before* removing anything, and the default widget is left on display. That also explains why the issue reproduces with the alternate layout enabled.

Guarding at the source — never adding the item for a hidden post — means neither layout can leave one behind:

```js
if (post.isHidden()) return;
```

The discussion-list components are unaffected: they key on the discussion rather than a post and are already gated on `seeVotes`.

### Testing

Frontend-only, and this extension has no JS suite, so this is not covered by an automated test. The PHP suite is unchanged and green (59 tests, 180 assertions).

To check by hand: with `altPostVotingUi` enabled, soft-delete a reply in a gamified tag — the vote buttons should be absent rather than showing behind the overlay.