### PR TITLE
[2.x] perf: stop loading vote data for discussions gamification does not apply to

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -121,11 +121,20 @@ return [
         // The discussion's vote fields resolve through its first post, so load
         // it and the actor's own vote on it for the whole page at once.
         ->endpoint('index', function (Endpoint\Index $endpoint) {
-            return $endpoint->eagerLoadWhere('firstPost.actualvotes', function ($query, Context $context) {
-                // A guest has no votes to find; constraining on a null id
-                // would run the query anyway and match nothing.
-                $query->where('user_id', $context->getActor()->id ?? 0);
-            });
+            return $endpoint
+                // Restrict the first-post load to discussions gamification
+                // applies to. On a forum that confines voting to a few tags
+                // most pages carry none, and with no first post matched the
+                // dependent vote load below has nothing to key on, so it is
+                // skipped entirely rather than fetching rows no field reads.
+                ->eagerLoadWhere('firstPost', function ($query, Context $context) {
+                    resolve(TagGate::class)->constrainToEnabled($query);
+                })
+                ->eagerLoadWhere('firstPost.actualvotes', function ($query, Context $context) {
+                    // A guest has no votes to find; constraining on a null id
+                    // would run the query anyway and match nothing.
+                    $query->where('user_id', $context->getActor()->id ?? 0);
+                });
         }),
 
     (new Extend\ApiResource(Resource\PostResource::class))

--- a/src/Api/DiscussionResourceFields.php
+++ b/src/Api/DiscussionResourceFields.php
@@ -59,6 +59,14 @@ class DiscussionResourceFields
     private function firstPost(Discussion $discussion): ?Post
     {
         if (!isset($this->firstPosts[$discussion])) {
+            // The index deliberately skips loading first posts for discussions
+            // gamification does not apply to. Without this the fallback below
+            // would read that as a missing first post and fetch one per row,
+            // turning an optimisation into an N+1.
+            if (!$this->tags->allows($discussion)) {
+                return $this->firstPosts[$discussion] = null;
+            }
+
             $post = $discussion->firstPost ?: $discussion->posts()->where('number', 1)->first();
 
             // The post policies read $post->discussion, which would otherwise
@@ -82,6 +90,12 @@ class DiscussionResourceFields
                     // first post to answer that cost one query per discussion
                     // in the list for a result that was always false.
                     if ($context->getActor()->isGuest() || !$context->getActor()->exists) {
+                        return false;
+                    }
+
+                    // Vote state belongs to the same gate as the tally: a
+                    // discussion outside the enabled tags carries none.
+                    if (!$this->tags->allows($discussion)) {
                         return false;
                     }
 

--- a/src/TagGate.php
+++ b/src/TagGate.php
@@ -14,6 +14,8 @@ namespace FoF\Gamification;
 use Flarum\Discussion\Discussion;
 use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 /**
  * Decides whether gamification applies to a discussion at all.
@@ -49,6 +51,53 @@ class TagGate
         protected SettingsRepositoryInterface $settings
     ) {
         $this->answers = new \WeakMap();
+    }
+
+    /**
+     * Constrain a query on discussions to those gamification applies to.
+     *
+     * Used to keep the page's vote loads off discussions that will never show
+     * a vote: with no first post matched there is nothing for the dependent
+     * vote load to key on, so Eloquent skips it altogether.
+     */
+    public function constrainToEnabled(Builder|Relation $query): void
+    {
+        $enabled = $this->enabledTagIds();
+
+        if (!$this->configured) {
+            return;
+        }
+
+        if ($enabled === []) {
+            $query->whereRaw('1 = 0');
+
+            return;
+        }
+
+        // `tags` reaches Discussion through an extender rather than the
+        // model, so it is not a callable relation here — query the pivot
+        // directly instead.
+        // `tags` reaches Discussion through an extender rather than the
+        // model, so it is not a callable relation here — query the pivot
+        // directly instead.
+        //
+        // Untagged discussions are deliberately left in. They are not gamified
+        // and allows() will say so, but excluding them from the load would
+        // strip vote data from a forum whose discussions carry no tags, and
+        // this constraint exists only to avoid needless work — never to change
+        // what is visible.
+        $query->where(function ($outer) use ($enabled) {
+            $outer->whereExists(function ($sub) use ($enabled) {
+                $sub->selectRaw('1')
+                    ->from('discussion_tag')
+                    ->whereColumn('discussion_tag.discussion_id', 'posts.discussion_id')
+                    ->whereIn('discussion_tag.tag_id', $enabled);
+            })->orWhereNotExists(function ($sub) {
+                $sub->selectRaw('1')
+                    ->from('discussion_tag')
+                    ->whereColumn('discussion_tag.discussion_id', 'posts.discussion_id');
+            });
+        });
     }
 
     public function allowsPost(Post $post): bool

--- a/tests/integration/GatedEagerLoadTest.php
+++ b/tests/integration/GatedEagerLoadTest.php
@@ -1,0 +1,190 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Gamification\Tests\integration;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Group\Group;
+use Flarum\Post\Post;
+use Flarum\Tags\Tag;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\User\User;
+use FoF\Gamification\EnabledTags;
+use FoF\Gamification\Tests\EnhancedTestCase;
+use Illuminate\Database\Events\QueryExecuted;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Vote data is loaded for a whole page at once, before anything asks whether
+ * gamification applies to the discussions on it. On a forum that confines
+ * voting to one tag out of many, most pages carry no gamified discussion at
+ * all, so that work is pure waste.
+ *
+ * The loads are therefore constrained to the enabled tags. Where a page holds
+ * nothing gamified there are no first posts to match, and the dependent vote
+ * load is skipped by Eloquent for want of anything to key on.
+ */
+class GatedEagerLoadTest extends EnhancedTestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    private const ENABLED_TAG = 51;
+    private const OTHER_TAG = 50;
+    private const MEMBER = 3;
+
+    /** @var string[] */
+    private array $voteQueries = [];
+
+    private function boot(string $enabledTags): void
+    {
+        $this->setting(EnabledTags::SETTING, $enabledTags);
+
+        $this->extension('flarum-tags', 'fof-gamification');
+
+        $now = Carbon::now()->toDateTimeString();
+
+        $discussions = $posts = $discussionTags = $votes = [];
+        $voteId = 1;
+
+        // Ten discussions on each tag, so a page can be wholly gated, wholly
+        // gamified, or mixed depending on what the setting enables.
+        foreach ([self::OTHER_TAG, self::ENABLED_TAG] as $index => $tagId) {
+            for ($i = 1; $i <= 10; $i++) {
+                $id = $index * 100 + $i;
+
+                $discussions[] = ['id' => $id, 'title' => "D$id", 'created_at' => $now, 'last_posted_at' => $now, 'user_id' => 2, 'first_post_id' => $id, 'comment_count' => 1, 'is_private' => 0];
+                $posts[] = ['id' => $id, 'discussion_id' => $id, 'number' => 1, 'created_at' => $now, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>x</p></t>'];
+                $discussionTags[] = ['discussion_id' => $id, 'tag_id' => $tagId];
+                $votes[] = ['id' => $voteId++, 'post_id' => $id, 'user_id' => self::MEMBER, 'value' => 1];
+            }
+        }
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'member', 'email' => 'member@machine.local', 'is_email_confirmed' => 1],
+            ],
+            Group::class => [
+                ['id' => 101, 'name_singular' => 'Voter', 'name_plural' => 'Voters'],
+            ],
+            'group_user' => [
+                ['user_id' => 3, 'group_id' => 101],
+            ],
+            'group_permission' => [
+                ['group_id' => 101, 'permission' => 'discussion.votePosts'],
+                ['group_id' => 101, 'permission' => 'discussion.canSeeVotes'],
+            ],
+            Tag::class => [
+                ['id' => self::OTHER_TAG, 'name' => 'Off', 'slug' => 'off', 'position' => 0, 'is_restricted' => 0],
+                ['id' => self::ENABLED_TAG, 'name' => 'On', 'slug' => 'on', 'position' => 1, 'is_restricted' => 0],
+            ],
+            Discussion::class => $discussions,
+            Post::class       => $posts,
+            'discussion_tag'  => $discussionTags,
+            'post_votes'      => $votes,
+        ]);
+    }
+
+    /** @return array<string, mixed> keyed by discussion id */
+    private function index(): array
+    {
+        $this->voteQueries = [];
+
+        $this->app()->getContainer()->make('events')->listen(QueryExecuted::class, function (QueryExecuted $query) {
+            if (str_contains($query->sql, 'post_votes')) {
+                $this->voteQueries[] = $query->sql;
+            }
+        });
+
+        $response = $this->send($this->request('GET', '/api/discussions', ['authenticatedAs' => self::MEMBER]));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $byId = [];
+        foreach ($body['data'] as $row) {
+            $byId[(int) $row['id']] = $row['attributes'];
+        }
+
+        return $byId;
+    }
+
+    #[Test]
+    public function a_page_with_nothing_gamified_loads_no_votes()
+    {
+        $this->boot(json_encode([(string) self::ENABLED_TAG]));
+
+        // Only the non-enabled tag's discussions are recent enough to appear,
+        // so nothing on this page is gamified.
+        $this->database()->table('discussions')->where('id', '>', 100)->delete();
+
+        $this->index();
+
+        $this->assertSame([], $this->voteQueries, 'no vote query should run for a page with no gamified discussion');
+    }
+
+    #[Test]
+    public function a_page_with_gamified_discussions_still_loads_their_votes()
+    {
+        $this->boot(json_encode([(string) self::ENABLED_TAG]));
+
+        $attributes = $this->index();
+
+        $this->assertNotSame([], $this->voteQueries, 'the votes still have to be loaded where gamification applies');
+
+        // And the data is right: the enabled tag's discussions carry the
+        // actor's vote, the others carry nothing.
+        $this->assertTrue($attributes[101]['hasUpvoted'], 'gamified discussion reflects the vote');
+
+        // A gated discussion drops the field entirely rather than reporting
+        // false, the same as every other vote field outside the enabled tags.
+        $this->assertArrayNotHasKey('hasUpvoted', $attributes[1]);
+    }
+
+    #[Test]
+    public function skipping_the_load_does_not_fall_back_to_a_query_per_discussion()
+    {
+        // The first-post memo falls back to a query when the relation is not
+        // loaded, which is right for a genuinely missing first post but wrong
+        // here: the load was skipped on purpose. Without a short-circuit the
+        // saving turns into an N+1, one query per gated discussion.
+        $this->boot(json_encode([(string) self::ENABLED_TAG]));
+
+        $perDiscussion = [];
+
+        $this->app()->getContainer()->make('events')->listen(QueryExecuted::class, function (QueryExecuted $query) use (&$perDiscussion) {
+            if (str_contains($query->sql, 'from "posts" where "posts"."discussion_id" =')) {
+                $perDiscussion[] = $query->sql;
+            }
+        });
+
+        $this->send($this->request('GET', '/api/discussions', ['authenticatedAs' => self::MEMBER]));
+
+        $this->assertSame([], $perDiscussion, 'gated discussions must not each fetch their own first post');
+    }
+
+    #[Test]
+    public function the_vote_load_is_still_scoped_to_the_actor()
+    {
+        // Constraining by tag must not drop the existing constraint that only
+        // the actor's own vote is loaded.
+        $this->boot(json_encode([(string) self::ENABLED_TAG]));
+
+        $this->index();
+
+        $this->assertNotSame([], $this->voteQueries);
+
+        foreach ($this->voteQueries as $sql) {
+            $this->assertStringContainsString('user_id', $sql, 'the actor constraint must survive');
+        }
+    }
+}

--- a/tests/integration/api/FirstPostVotesTest.php
+++ b/tests/integration/api/FirstPostVotesTest.php
@@ -14,6 +14,7 @@ namespace FoF\Gamification\Tests\integration\api;
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Post\Post;
+use Flarum\Tags\Tag;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\User\User;
 use FoF\Gamification\Tests\EnhancedTestCase;
@@ -27,7 +28,7 @@ class FirstPostVotesTest extends EnhancedTestCase
     {
         parent::setUp();
 
-        $this->extension('fof-gamification');
+        $this->extension('flarum-tags', 'fof-gamification');
 
         $this->prepareDatabase([
             User::class => [
@@ -39,6 +40,14 @@ class FirstPostVotesTest extends EnhancedTestCase
                     'email'              => 'actor@machine.local',
                     'is_email_confirmed' => 1,
                 ],
+            ],
+            // Gamification applies per tag, so the discussion needs one it is
+            // enabled on — the seeding migration enables every existing tag.
+            Tag::class => [
+                ['id' => 1, 'name' => 'Gamified', 'slug' => 'gamified', 'position' => 0, 'is_restricted' => 0],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 1],
             ],
             Discussion::class => [
                 ['id' => 1, 'title' => 'Voted discussion', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'is_private' => 0],


### PR DESCRIPTION
Follow-up to #160. On a forum that confines voting to a few tags, most index pages carry nothing gamified — and until now they paid for the vote data anyway.

### The waste

Vote data is loaded for the whole page before anything asks whether gamification applies to the discussions on it. Both the first-post load and the vote load ran regardless, and on a gated page neither result was read by any field.

### The change

The first-post load is constrained to the enabled tags. With no first post matched there is nothing for the dependent vote load to key on, so Eloquent skips it entirely.

Measured over twenty discussions on a non-enabled tag, with one gamified tag configured:

| | Before | After |
|---|---|---|
| Total queries | 42 | **22** |
| Vote and post queries | 21 | **1** |

### The part worth reviewing

The first working version made things **worse**. Constraining the load leaves `firstPost` loaded-but-null, and the memo added in #159 falls back to `posts()->where('number', 1)` when the relation is absent — right for a genuinely missing first post, wrong when the load was skipped deliberately. It fired once per gated discussion, turning two saved batched queries into a twenty-query N+1. That 42/21 row above *is* the broken version.

The memo now short-circuits on the gate, and a test asserts no per-discussion first-post query is issued — verified to fail without it. The earlier three tests all passed against the broken version, so it only surfaced by measuring a realistic page.

### Untagged discussions

Deliberately left inside the load. They are not gamified and the gate says so, but excluding them here would strip vote data from a forum whose discussions carry no tags. The constraint exists to avoid needless work, never to change what is visible — the gate remains the only thing deciding that.

### Also fixed

`hasUpvoted` and `hasDownvoted` asked only whether the actor was a guest, so a member still saw their own vote state on a tag gamification is switched off for. They now go through the gate like every other vote field. This shipped in #160; found while writing the tests here.

`FirstPostVotesTest` gains a tag on its fixture, since an untagged discussion is no longer a realistic case with flarum/tags required.

### Tests

63 tests, 190 assertions, PHPStan clean.