### PR TITLE
[2.x] Honour the rankings exclusion list however it is typed

### DIFF
--- a/src/Filter/RankableFilter.php
+++ b/src/Filter/RankableFilter.php
@@ -38,10 +38,41 @@ class RankableFilter implements FilterInterface
             throw new PermissionDeniedException();
         }
 
-        $blockedUsers = explode(', ', $this->settings->get('fof-gamification.blockedUsers'));
+        $excluded = $this->excludedUsernames();
 
+        if ($excluded === []) {
+            return;
+        }
+
+        // Deliberately ignores $negate. This filter answers "may this user
+        // appear in the rankings?", which has no useful inverse — and honouring
+        // the negation would turn the exclusion inside out, so `filter[-rankable]`
+        // would return precisely the list of people the admin asked to hide.
         $state
             ->getQuery()
-            ->whereIn('username', $blockedUsers, 'and', !$negate);
+            ->whereNotIn('username', $excluded);
+    }
+
+    /**
+     * The excluded usernames, as the admin typed them.
+     *
+     * Stored as free text, so the separator is whatever the admin used: split
+     * on commas with any surrounding whitespace rather than a literal ', ',
+     * which silently matched nothing for the more natural `alice,bob`.
+     *
+     * @return string[]
+     */
+    private function excludedUsernames(): array
+    {
+        $setting = (string) $this->settings->get('fof-gamification.blockedUsers');
+
+        if (trim($setting) === '') {
+            return [];
+        }
+
+        return array_values(array_filter(
+            preg_split('/\s*,\s*/', trim($setting)) ?: [],
+            fn (string $username) => $username !== ''
+        ));
     }
 }

--- a/tests/integration/api/RankableExclusionTest.php
+++ b/tests/integration/api/RankableExclusionTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Gamification\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\User\User;
+use FoF\Gamification\Tests\EnhancedTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The `rankable` filter decides who appears on the rankings page, so the
+ * excluded-users setting is the only thing keeping an admin's chosen names off
+ * it.
+ *
+ * The list is stored as free text, which means the parsing has to cope with
+ * however an admin actually typed it, and the filter has to stay closed no
+ * matter what the caller passes as the filter value.
+ */
+class RankableExclusionTest extends EnhancedTestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * Seed with a fixed excluded-users setting.
+     *
+     * Settings must be staged before anything boots the app, so each test calls
+     * this instead of setUp() doing it once.
+     */
+    private function boot(string $blockedUsers): void
+    {
+        $this->setting('fof-gamification.blockedUsers', $blockedUsers);
+
+        $this->extension('fof-gamification');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                $this->userWithVotes(3, 'alice', 50),
+                $this->userWithVotes(4, 'bob', 200),
+                $this->userWithVotes(5, 'carol', 100),
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function userWithVotes(int $id, string $username, int $votes): array
+    {
+        return [
+            'id'                 => $id,
+            'username'           => $username,
+            'email'              => "{$username}@machine.local",
+            'is_email_confirmed' => 1,
+            'votes'              => $votes,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $filter
+     *
+     * @return string[] the usernames returned, in response order
+     */
+    private function rankedUsernames(array $filter = ['rankable' => 'true']): array
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users', ['authenticatedAs' => 1])
+                ->withQueryParams(['filter' => $filter, 'sort' => '-votes'])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->__toString());
+
+        $data = json_decode($response->getBody()->__toString(), true)['data'];
+
+        $names = array_map(fn ($user) => $user['attributes']['username'] ?? null, $data);
+
+        // Only the seeded users are of interest; the actor is incidental.
+        return array_values(array_intersect($names, ['alice', 'bob', 'carol']));
+    }
+
+    #[Test]
+    public function an_empty_setting_excludes_nobody()
+    {
+        $this->boot('');
+
+        $this->assertEquals(['bob', 'carol', 'alice'], $this->rankedUsernames());
+    }
+
+    #[Test]
+    public function a_comma_space_list_excludes_those_users()
+    {
+        $this->boot('alice, carol');
+
+        $this->assertEquals(['bob'], $this->rankedUsernames());
+    }
+
+    /**
+     * The separator an admin is most likely to type. Splitting on a literal
+     * ', ' leaves this as one unmatched name, so nobody is excluded and the
+     * setting silently does nothing.
+     */
+    #[Test]
+    public function a_list_without_spaces_still_excludes_those_users()
+    {
+        $this->boot('alice,carol');
+
+        $this->assertEquals(['bob'], $this->rankedUsernames());
+    }
+
+    /**
+     * Stray whitespace and trailing separators are ordinary in a free-text
+     * field and must not turn into empty names that match nothing.
+     */
+    #[Test]
+    public function untidy_input_is_parsed_forgivingly()
+    {
+        $this->boot("  alice ,\tcarol , ");
+
+        $this->assertEquals(['bob'], $this->rankedUsernames());
+    }
+
+    /**
+     * The filter value comes from the query string. Negating it must not turn
+     * the exclusion inside out and hand back precisely the list of people the
+     * admin asked to hide.
+     */
+    #[Test]
+    public function negating_the_filter_cannot_enumerate_the_excluded_users()
+    {
+        $this->boot('alice, carol');
+
+        $names = $this->rankedUsernames(['-rankable' => 'true']);
+
+        $this->assertNotContains('alice', $names, 'a negated filter must not reveal excluded users');
+        $this->assertNotContains('carol', $names, 'a negated filter must not reveal excluded users');
+    }
+}


### PR DESCRIPTION
The excluded-users setting on the rankings page is a free-text field, but `RankableFilter` split it on a literal `", "`.

## Parsing

`alice,bob` — the most natural way to type a list — parsed as one name that matched nobody, so the setting silently did nothing. Same for stray whitespace or a trailing comma. It now splits on commas with any surrounding whitespace and drops empty entries.

An empty setting previously built `whereNotIn('username', [''])`; it now skips the clause entirely.

## Negation

The filter passed `!$negate` through to `whereIn`, so a request for `filter[-rankable]` inverted the `NOT IN` into an `IN` and returned exactly the users the admin had asked to hide.

"May this user appear in the rankings?" has no useful inverse, so `$negate` is now ignored and the query is always an exclusion.

## Testing

`RankableExclusionTest` covers the empty setting, a comma-space list, a list without spaces, untidy input with tabs and a trailing separator, and the negated filter key.

Verified against the previous code: the no-space and untidy cases returned all three users instead of one, and `filter[-rankable]=true` returned the two excluded users by name. All five pass with the fix; 71 integration tests and PHPStan are green.

Note the negation vector is the `-` prefix on the filter *key*, not a `false` value — `filter[rankable]=false` is not negation and was never affected.

Usernames remain the matching key here. Moving exclusions to user IDs (so a rename does not quietly lapse the exclusion) needs a migration and is left for the leaderboard rework.