### PR TITLE
[2.x] fix: nest the gambit translations under the extension namespace

### DIFF
--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -191,7 +191,7 @@ fof-gamification:
     subject:
       postVoted: Your post was voted on by {display_name}
 
-lib:
+  lib:
     gambits:
       trending:
         key: trending


### PR DESCRIPTION
The `is:` line in the search modal listed a raw translation key instead of `trending`:

```
is: hidden, unread, following, ignoring, solved, private, locked, fof-gamification.lib.gambits.t…
```

`lib` sat at the root of `resources/locale/en.yml` rather than under `fof-gamification`, giving the file two top-level namespaces. `TrendingGambit` asks for `fof-gamification.lib.gambits.trending.key`, the translator only had `lib.gambits.trending.key`, and since the gambit resolves its key in raw mode the miss returned the key itself for display.

The block has been at the wrong level since #131, so the gambit has never shown a usable label on 2.x — #165 renamed `hot` to `trending` and carried the indentation with it.

Verified by parsing the file with the same YAML component Flarum uses: one top-level key afterwards, and `fof-gamification.lib.gambits.trending.key` resolving to `trending`.

Not fixed here, and not caused by this: the row still clips rather than wraps when the joined `is:` values outgrow the modal. That is core styling (`.GambitsAutocomplete-gambit` is a flex row with no `min-width: 0` and no wrapping on the value), and it gets worse as more extensions register boolean gambits. Being handled separately in core.