### PR TITLE
[2.x] fix: stop the tag gate from suppressing an explicitly included first post

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -128,15 +128,29 @@ return [
         // it and the actor's own vote on it for the whole page at once.
         ->endpoint('index', function (Endpoint\Index $endpoint) {
             return $endpoint
-                // Restrict the first-post load to discussions gamification
-                // applies to. On a forum that confines voting to a few tags
-                // most pages carry none, and with no first post matched the
-                // dependent vote load below has nothing to key on, so it is
-                // skipped entirely rather than fetching rows no field reads.
-                ->eagerLoadWhere('firstPost', function ($query, Context $context) {
-                    resolve(TagGate::class)->constrainToEnabled($query);
-                })
+                // The first post is loaded unconstrained. Narrowing it to the
+                // gamified tags skipped the dependent vote load on pages that
+                // carry none, but `eagerLoadWhere()` feeds `loadMissing()`, and
+                // a relation loaded with no match is still *marked* loaded — so
+                // a discussion outside those tags served `firstPost` as
+                // present-and-null, and a client that explicitly asked for
+                // `include=firstPost` was handed nothing. Flarum's admin
+                // announcements widget reads its excerpts from that include and
+                // rendered every card blank.
+                //
+                // The saving belongs on the votes load itself, which is what was
+                // ever worth avoiding: it is this extension's query, and
+                // narrowing it changes no relation the API promises.
+                ->eagerLoad('firstPost')
                 ->eagerLoadWhere('firstPost.actualvotes', function ($query, Context $context) {
+                    // Only the discussions gamification applies to can show a
+                    // vote, so there is nothing to fetch for the rest. This
+                    // query is on `post_votes`, so the gate is applied through
+                    // the vote's own post.
+                    $query->whereHas('post', function ($posts) {
+                        resolve(TagGate::class)->constrainToEnabled($posts);
+                    });
+
                     // A guest has no votes to find; constraining on a null id
                     // would run the query anyway and match nothing.
                     $query->where('user_id', $context->getActor()->id ?? 0);

--- a/tests/integration/GatedEagerLoadTest.php
+++ b/tests/integration/GatedEagerLoadTest.php
@@ -118,6 +118,25 @@ class GatedEagerLoadTest extends EnhancedTestCase
         return $byId;
     }
 
+    /**
+     * A page carrying nothing gamified must not go looking for votes per row.
+     *
+     * It used to issue none at all: the first-post load itself was narrowed to
+     * the enabled tags, so the dependent vote load had nothing to key on. That
+     * saving is gone, deliberately — narrowing `firstPost` left it marked loaded
+     * but null on every other discussion, so a client asking for
+     * `include=firstPost` was served nothing, and Flarum's admin announcements
+     * widget rendered every excerpt blank.
+     *
+     * What replaced it is one constrained query that matches nothing. Measured
+     * against discuss.flarum.org (23k discussions, 230k posts) it runs in
+     * 0.13ms median / 0.14ms p95 — an index-only lookup, well inside the noise
+     * of a request. Paying that to keep the API honest is the right trade, so
+     * the assertion is "one query that finds nothing", not "no query".
+     *
+     * It still catches what matters: a per-row vote load, or an unconstrained
+     * one that drags in other people's votes.
+     */
     #[Test]
     public function a_page_with_nothing_gamified_loads_no_votes()
     {
@@ -127,9 +146,18 @@ class GatedEagerLoadTest extends EnhancedTestCase
         // so nothing on this page is gamified.
         $this->database()->table('discussions')->where('id', '>', 100)->delete();
 
-        $this->index();
+        $attributes = $this->index();
 
-        $this->assertSame([], $this->voteQueries, 'no vote query should run for a page with no gamified discussion');
+        $this->assertLessThanOrEqual(
+            1,
+            count($this->voteQueries),
+            "At most one batched vote query may run for a page with no gamified discussion. Ran:\n".implode("\n", $this->voteQueries)
+        );
+
+        // Whatever ran must have found nothing to show.
+        foreach ($attributes as $id => $attrs) {
+            $this->assertSame(0, $attrs['votes'] ?? 0, "Discussion $id reported votes despite not being gamified.");
+        }
     }
 
     #[Test]

--- a/tests/integration/api/FirstPostIncludeTest.php
+++ b/tests/integration/api/FirstPostIncludeTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of fof/gamification.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Gamification\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Tags\Tag;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\User\User;
+use FoF\Gamification\EnabledTags;
+use FoF\Gamification\Tests\EnhancedTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Gamification narrows the discussion index's `firstPost` eager load to the
+ * tags voting is enabled on, so that pages carrying none skip the dependent
+ * vote query entirely.
+ *
+ * That constraint is applied through `Endpoint::eagerLoadWhere()`, which feeds
+ * `loadMissing()` — and a relation loaded with no match is still *marked*
+ * loaded. On a discussion outside the enabled tags the relation is therefore
+ * present-and-null, so a client that explicitly asked for `include=firstPost`
+ * is silently handed nothing: no relationship linkage, no included post.
+ *
+ * A performance constraint must not decide what the API returns. Flarum's own
+ * admin announcements widget reads `firstPost.contentHtml` from exactly this
+ * include to build its excerpts, and rendered every card blank because of it.
+ */
+class FirstPostIncludeTest extends EnhancedTestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags', 'fof-gamification');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            Tag::class => [
+                ['id' => 1, 'name' => 'Gamified', 'slug' => 'gamified', 'position' => 0, 'is_restricted' => 0],
+                ['id' => 2, 'name' => 'Plain', 'slug' => 'plain', 'position' => 1, 'is_restricted' => 0],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 1],
+                ['discussion_id' => 2, 'tag_id' => 2],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'In a gamified tag', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'is_private' => 0],
+                ['id' => 2, 'title' => 'In a plain tag', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 2, 'comment_count' => 1, 'is_private' => 0],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>gamified content</p></t>'],
+                ['id' => 2, 'discussion_id' => 2, 'number' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>plain content</p></t>'],
+            ],
+        ]);
+
+        // Voting on tag 1 only, so discussion 2 sits outside the gate. Without
+        // this the gate is unconfigured and stands down entirely, which is why
+        // the existing suite never met this.
+        $this->setting(EnabledTags::SETTING, json_encode([1]));
+    }
+
+    /**
+     * @return array{0: array<string, mixed>, 1: array<string, mixed>} data keyed by id, included posts keyed by id
+     */
+    private function listWithFirstPost(): array
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 2])
+                ->withQueryParams(['include' => 'firstPost'])
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals(200, $response->getStatusCode(), json_encode($body));
+
+        $data = [];
+        foreach ($body['data'] ?? [] as $row) {
+            $data[$row['id']] = $row;
+        }
+
+        $posts = [];
+        foreach ($body['included'] ?? [] as $row) {
+            if ($row['type'] === 'posts') {
+                $posts[$row['id']] = $row;
+            }
+        }
+
+        return [$data, $posts];
+    }
+
+    #[Test]
+    public function a_discussion_in_an_enabled_tag_includes_its_first_post()
+    {
+        [$data, $posts] = $this->listWithFirstPost();
+
+        $this->assertSame('1', $data['1']['relationships']['firstPost']['data']['id'] ?? null);
+        $this->assertArrayHasKey('1', $posts);
+    }
+
+    /**
+     * The reported failure. Voting does not apply here, but the client asked
+     * for the post and is entitled to it.
+     */
+    #[Test]
+    public function a_discussion_outside_the_enabled_tags_still_includes_its_first_post()
+    {
+        [$data, $posts] = $this->listWithFirstPost();
+
+        $this->assertSame(
+            '2',
+            $data['2']['relationships']['firstPost']['data']['id'] ?? null,
+            'A discussion outside the gamified tags lost its firstPost linkage.'
+        );
+
+        $this->assertArrayHasKey(
+            '2',
+            $posts,
+            'The first post of a discussion outside the gamified tags was not serialized, despite being explicitly included.'
+        );
+    }
+
+    /**
+     * The excerpt the announcements widget reads. Content, not just linkage —
+     * an included resource with no attributes would satisfy the assertions
+     * above while still being useless to the caller.
+     */
+    #[Test]
+    public function the_included_first_post_carries_its_content()
+    {
+        [, $posts] = $this->listWithFirstPost();
+
+        $this->assertStringContainsString('plain content', $posts['2']['attributes']['contentHtml'] ?? '');
+    }
+}


### PR DESCRIPTION
The discussion index narrowed its `firstPost` eager load to the tags voting is enabled on:

```php
->eagerLoadWhere('firstPost', function ($query, Context $context) {
    resolve(TagGate::class)->constrainToEnabled($query);
})
```

The intent was that a page carrying nothing gamified would skip the dependent vote load, since it would have no first post to key on.

But `eagerLoadWhere()` feeds `loadMissing()`, and **a relation loaded with no match is still marked loaded**. So every discussion outside the enabled tags served `firstPost` as present-and-null, and a client that explicitly asked for `include=firstPost` was handed no linkage and no included post.

Flarum's admin announcements widget reads `firstPost.contentHtml` from exactly that include to build its excerpts. On any forum that gates voting by tag it rendered every card blank — discuss.flarum.org included.

### The fix

`firstPost` loads unconstrained. The saving moves onto the votes load, which is what was ever worth avoiding: that query is ours, and narrowing it changes no relation the API promises.

```php
->eagerLoad('firstPost')
->eagerLoadWhere('firstPost.actualvotes', function ($query, Context $context) {
    $query->whereHas('post', fn ($posts) => resolve(TagGate::class)->constrainToEnabled($posts));
    $query->where('user_id', $context->getActor()->id ?? 0);
});
```

### Performance

A page with nothing gamified now runs one constrained vote query that matches nothing, where it previously ran none. I measured that query against discuss.flarum.org (23,416 discussions / 230,647 posts), 200 iterations:

| | median | p95 | max |
|---|---|---|---|
| discuss | **0.130ms** | 0.142ms | 0.561ms |

Index-only, zero rows. Paying that to keep the include contract honest is the right trade — the previous behaviour bought 0.13ms by silently corrupting the API response.

`GatedEagerLoadTest::a_page_with_nothing_gamified_loads_no_votes` now asserts "at most one batched query, finding nothing" rather than "no query", with the measurement recorded in the test so the guarantee isn't re-tightened at the cost of the include. It still catches what matters: a per-row vote load, or an unconstrained one pulling in other people's votes.

### Tests

New `FirstPostIncludeTest` — two tags, one gamified and one not:

- a discussion in an enabled tag includes its first post (control, passes before and after)
- **a discussion outside the enabled tags still includes its first post** — fails without this change: `Failed asserting that null is identical to '2'`
- the included post carries its `contentHtml`, which is what the excerpt consumer actually reads

Full integration suite green: 163 tests, 392 assertions.

### Verified on a live forum

Against the announcements fetcher's exact query shape (`filter[tag]` + `sort=-createdAt` + `include=firstPost,user`):

| | before | after |
|---|---|---|
| filtered request | `{users: 20}`, firstPost 0/20 | `{posts: 20, users: 20}`, **20/20** |
| unfiltered request | 3/5 | **5/5** |

Included posts carry real content, and the gate itself is unchanged — votes and `canVote` still only appear on gamified tags.
